### PR TITLE
Added interior rain option for portable tents / overhangs

### DIFF
--- a/Misc/ashfallTentSounds.lua
+++ b/Misc/ashfallTentSounds.lua
@@ -1,0 +1,228 @@
+local modversion = require("tew.AURA.version")
+local version = modversion.version
+local config = require("tew.AURA.config")
+local sounds = require("tew.AURA.sounds")
+local common = require("tew.AURA.common")
+local debugLog = common.debugLog
+local ashfall = include("mer.ashfall.common.common")
+local moduleName = "ashfallTent"
+local WtC
+local currentWeather
+local nextWeather
+local trackLoaded = false
+local timerInProgress = false
+local rainAboutToStop = false
+local rainAboutToStart = false
+local transitionDelay = 0
+
+local TICK = 0.1
+
+local tracks = {
+    [4] = "tew_at_rainmedium",
+    [5] = "tew_at_rainheavy",
+}
+
+local function updateWeather()
+    if WtC.nextWeather then
+        nextWeather = WtC.nextWeather.index
+    else
+        nextWeather = nil
+    end
+    currentWeather = WtC.currentWeather.index
+end
+
+local function isTrackPlaying()
+    if not trackLoaded then return false end
+    updateWeather()
+    local playingNow = {
+        tracks[currentWeather],
+        tracks[nextWeather],
+    }
+    for _, v in pairs(playingNow) do
+        if tes3.getSoundPlaying{sound = v, reference = tes3.mobilePlayer.reference} then
+            return true
+        end
+    end
+    trackLoaded = false
+    return false
+end
+
+local function isBadWeather(weatherIndex)
+    if (weatherIndex == 4) or (weatherIndex == 5) then
+        return true
+    end
+    return false
+end
+
+local function isRaining()
+    if rainAboutToStop then return false end
+    if rainAboutToStart then return true end
+
+    updateWeather()
+    return isBadWeather(currentWeather)
+end
+
+local function stopTentSound()
+    if timerInProgress then return end
+    local fadeStep = 0.050
+    local delay = 0.1
+    local volume = 1
+    local TIME = TICK*volume/fadeStep
+    if isTrackPlaying() then
+        sounds.remove{
+            module = moduleName,
+            volume = volume,
+            fadeStep = fadeStep,
+            clearNewTrack = true,
+        }
+        timerInProgress = true
+        timer.start{
+            iterations = 1,
+            duration = TIME + delay + transitionDelay,
+            callback = function()
+                timerInProgress = false
+                if transitionDelay > 0 then transitionDelay = 0 end
+            end
+        }
+    end
+end
+
+local function playTentSound()
+    if timerInProgress then return end
+    if rainAboutToStop then return end
+    local fadeStep = 0.13
+    local delay = 0.1
+    local volume = 1
+    local TIME = TICK*volume/fadeStep
+    local weather
+
+    if isBadWeather(nextWeather) then
+        weather = nextWeather
+    else
+        weather = currentWeather
+    end
+
+    if (not isTrackPlaying()) then
+        debugLog("About to play track: " .. tostring(tracks[weather]))
+        sounds.play{
+            module = moduleName,
+            volume = volume,
+            type = "ate",
+            weather = weather,
+            fadeStep = fadeStep,
+            skipCrossfade = true,
+        }
+        timerInProgress = true
+        trackLoaded = true
+        timer.start{
+            iterations = 1,
+            duration = TIME + delay,
+            callback = function()
+                updateWeather()
+                timerInProgress = false
+            end
+        }
+    end
+end
+
+local function onSimulate(e)
+    if ashfall.data.insideTent then
+        if isRaining() then
+            playTentSound()
+        else
+            stopTentSound()
+        end
+    else
+        stopTentSound()
+    end
+end
+
+local function getTransToRainyDelay(toWeatherIndex)
+
+    -- Rough estimations of the time it takes to transition to rainy weather.
+    -- From NON-rainy to rainy as well as from rainy to rainy weather.
+    -- Starting point is when weatherTransitionStarted triggers.
+    -- Ending point is somewhere before weatherTransitionFinished
+    -- because rainLoopSound actually kicks in before the weather fully
+    -- transitions.
+
+    -- And because immersion.
+
+    -- These values are based on personal measurements
+    -- (and preferences).
+    -- Tested with vanilla morrowind.ini
+    -- May be inconsistent across various setups.
+    -- Feel free to tinker with.
+
+    updateWeather()
+
+    if (not isBadWeather(currentWeather)) then
+        if toWeatherIndex == 4 then return 45 end
+        if toWeatherIndex == 5 then return 30 end
+    else
+        if toWeatherIndex == 4 then return 40 end
+        if toWeatherIndex == 5 then return 25 end
+    end
+
+    return 0
+end
+
+local function onTransitionStarted(e)
+    debugLog("Weather transition started...")
+    transitionDelay = 0
+    if (not isRaining()) and
+        ((e.to.name == "Rain") or (e.to.name == "Thunderstorm")) then
+            debugLog("...non-rainy -> rainy")
+            rainAboutToStart = true
+            timerInProgress = true
+            timer.start{
+                iterations = 1,
+                duration = getTransToRainyDelay(e.to.index),
+                callback = function()
+                    timerInProgress = false
+                end
+            }
+    elseif isRaining() and
+            ((e.to.name ~= "Rain") and (e.to.name ~= "Thunderstorm")) then
+                debugLog("...rainy -> non-rainy")
+                rainAboutToStop = true
+                stopTentSound()
+    elseif isRaining() and
+            ((e.to.name == "Rain") or (e.to.name == "Thunderstorm")) then
+                debugLog("...rainy -> rainy")
+                rainAboutToStop = false
+                transitionDelay = getTransToRainyDelay(e.to.index)
+                stopTentSound()
+    end
+end
+
+local function onTransitionFinished()
+    debugLog("Weather transition finished.")
+    rainAboutToStop = false
+    rainAboutToStart = false
+    transitionDelay = 0
+end
+
+local function onCOC()
+    sounds.removeImmediate { module = moduleName }
+    -- Prevent playing tracks for a little while in order to allow
+    -- ashfall.data.insideTent to update after a cell change 
+    timerInProgress = true
+    timer.start{
+        iterations = 1,
+        duration = 2,
+        callback = function()
+            timerInProgress = false
+        end
+    }
+end
+
+if ashfall and config.ashfallTentSounds then
+    WtC = tes3.worldController.weatherController
+    event.register("simulate", onSimulate, {priority=-234})
+    event.register("weatherTransitionStarted", onTransitionStarted, {priority=-233})
+    event.register("weatherTransitionFinished", onTransitionFinished, {priority=-233})
+    event.register("weatherTransitionImmediate", onTransitionFinished, {priority=-233})
+    event.register("weatherChangedImmediate", onTransitionFinished, {priority=-233})
+    event.register("cellChanged", onCOC, {priority=-170})
+end

--- a/Misc/miscMain.lua
+++ b/Misc/miscMain.lua
@@ -9,6 +9,7 @@ local function init()
     local playYurtFlap = config.playYurtFlap
     local rainSounds = config.rainSounds
     local windSounds = config.windSounds
+    local ashfallTentSounds = config.ashfallTentSounds
 
     if playSplash and not moduleAmbientOutdoor then
         mwse.log(string.format("[AURA %s] %s waterSplash.lua.", version, messages.loadingFile))
@@ -28,6 +29,11 @@ local function init()
     if windSounds then
         mwse.log(string.format("[AURA %s] %s windSounds.lua.", version, messages.loadingFile))
         dofile("Data Files\\MWSE\\mods\\tew\\AURA\\Misc\\windSounds.lua")
+    end
+
+    if ashfallTentSounds then
+        mwse.log(string.format("[AURA %s] %s ashfallTentSounds.lua.", version, messages.loadingFile))
+        dofile("Data Files\\MWSE\\mods\\tew\\AURA\\Misc\\ashfallTentSounds.lua")
     end
 end
 

--- a/Misc/miscMain.lua
+++ b/Misc/miscMain.lua
@@ -9,7 +9,7 @@ local function init()
     local playYurtFlap = config.playYurtFlap
     local rainSounds = config.rainSounds
     local windSounds = config.windSounds
-    local ashfallTentSounds = config.ashfallTentSounds
+    local shelterSounds = config.shelterSounds
 
     if playSplash and not moduleAmbientOutdoor then
         mwse.log(string.format("[AURA %s] %s waterSplash.lua.", version, messages.loadingFile))
@@ -31,9 +31,9 @@ local function init()
         dofile("Data Files\\MWSE\\mods\\tew\\AURA\\Misc\\windSounds.lua")
     end
 
-    if ashfallTentSounds then
-        mwse.log(string.format("[AURA %s] %s ashfallTentSounds.lua.", version, messages.loadingFile))
-        dofile("Data Files\\MWSE\\mods\\tew\\AURA\\Misc\\ashfallTentSounds.lua")
+    if shelterSounds then
+        mwse.log(string.format("[AURA %s] %s shelterSounds.lua.", version, messages.loadingFile))
+        dofile("Data Files\\MWSE\\mods\\tew\\AURA\\Misc\\shelterSounds.lua")
     end
 end
 

--- a/Misc/rainSounds.lua
+++ b/Misc/rainSounds.lua
@@ -38,6 +38,11 @@ local interiorRainLoops = {
         ["light"] = "tew_t_rainlight",
         ["medium"] = "tew_t_rainmedium",
         ["heavy"] = "tew_t_rainheavy",
+    },
+    ["ate"] = {
+        ["light"] = "tew_at_rainmedium",
+        ["medium"] = "tew_at_rainmedium",
+        ["heavy"] = "tew_at_rainheavy",
     }
 }
 

--- a/Misc/rainSounds.lua
+++ b/Misc/rainSounds.lua
@@ -39,10 +39,10 @@ local interiorRainLoops = {
         ["medium"] = "tew_t_rainmedium",
         ["heavy"] = "tew_t_rainheavy",
     },
-    ["ate"] = {
-        ["light"] = "tew_at_rainlight",
-        ["medium"] = "tew_at_rainmedium",
-        ["heavy"] = "tew_at_rainheavy",
+    ["she"] = {
+        ["light"] = "tew_sh_rainlight",
+        ["medium"] = "tew_sh_rainmedium",
+        ["heavy"] = "tew_sh_rainheavy",
     }
 }
 

--- a/Misc/rainSounds.lua
+++ b/Misc/rainSounds.lua
@@ -40,7 +40,7 @@ local interiorRainLoops = {
         ["heavy"] = "tew_t_rainheavy",
     },
     ["ate"] = {
-        ["light"] = "tew_at_rainmedium",
+        ["light"] = "tew_at_rainlight",
         ["medium"] = "tew_at_rainmedium",
         ["heavy"] = "tew_at_rainheavy",
     }

--- a/Misc/shelterSounds.lua
+++ b/Misc/shelterSounds.lua
@@ -4,8 +4,7 @@ local config = require("tew.AURA.config")
 local sounds = require("tew.AURA.sounds")
 local common = require("tew.AURA.common")
 local debugLog = common.debugLog
-local ashfall = include("mer.ashfall.common.common")
-local moduleName = "ashfallTent"
+local moduleName = "shelter"
 local WtC
 local currentWeather
 local nextWeather
@@ -15,10 +14,115 @@ local timerInProgress = false
 local TICK = 0.1
 
 local tracks = {
-    "tew_at_rainlight",
-    "tew_at_rainmedium",
-    "tew_at_rainheavy",
+    "tew_sh_rainlight",
+    "tew_sh_rainmedium",
+    "tew_sh_rainheavy",
 }
+
+local shelters = {
+
+    -- Add only lower case object ids here
+
+    -- vanilla tents
+    "ex_ashl_tent_03",
+    "ex_ashl_tent_04",
+    "ex_velothi_hilltent_01",
+    "ex_mh_bazaar_tent",
+
+    -- vanilla overhangs
+    "furn_de_overhang_01",
+    "furn_de_overhang_02",
+    "furn_de_overhang_03",
+    "furn_de_overhang_04",
+    "furn_de_overhang_05",
+    "furn_de_overhang_06",
+    "furn_de_overhang_07",
+    "furn_de_overhang_09",
+    "furn_de_overhang_18",
+
+    -- legacy Ashfall tents
+    "ashfall_tent_test_active",
+    "ashfall_tent_active",
+    "ashfall_tent_ashl_active",
+    "ashfall_tent_canv_b_active",
+
+    -- Ashfall modular tents
+    'ashfall_tent_base_a',
+    'ashfall_tent_imp_a',
+    'ashfall_tent_qual_a',
+    'ashfall_tent_ashl_a',
+    'ashfall_tent_leather_a',
+
+    -- Ashlander Traders Remastered tents
+    "rp_ashl_tent_04",
+}
+
+local function cellIsInterior()
+    local cell = tes3.getPlayerCell()
+    if cell and
+        cell.isInterior and
+        (not cell.behavesAsExterior) then
+        return true
+    else
+        return false
+    end
+end
+
+local function isPlayerOutdoorSheltered()
+
+    -- Essentially Ashfall's checkRefSheltered()
+    -- but reworked to return true if the player
+    -- is sheltered inside one of the object ids
+    -- stored in the shelters table, or false otherwise.
+
+    if cellIsInterior() then
+        return false
+    end
+
+    local sheltered = false
+    local match = false
+    local reference = tes3.player
+
+    local height = reference.object.boundingBox
+        and reference.object.boundingBox.max.z or 0
+
+    local results = tes3.rayTest{
+        position = {
+            reference.position.x,
+            reference.position.y,
+            reference.position.z + (height/2)
+        },
+        direction = {0, 0, 1},
+        findAll = true,
+        maxDistance = 5000,
+        ignore = {reference},
+        useBackTriangles = true,
+    }
+    if results then
+        for _, result in ipairs(results) do
+            match = false
+            if result and result.reference and result.reference.object then
+                sheltered =
+                    ( result.reference.object.objectType == tes3.objectType.static or
+                    result.reference.object.objectType == tes3.objectType.activator ) == true
+                for _, objId in pairs(shelters) do
+                    if objId == result.reference.object.id:lower() then
+                        match = true
+                        break
+                    end
+                end
+                if sheltered == true then
+                    break
+                end
+            end
+        end
+    end
+    if sheltered and match then
+        return true
+    else
+        return false
+    end
+end
 
 local function isBadWeather(weatherIndex)
     if (weatherIndex == 4) or (weatherIndex == 5) then
@@ -102,7 +206,7 @@ local function playTentSound()
         sounds.play{
             module = moduleName,
             volume = volume,
-            type = "ate",
+            type = "she",
             weather = weather,
             fadeStep = fadeStep,
             skipCrossfade = true,
@@ -121,7 +225,7 @@ local function playTentSound()
 end
 
 local function onSimulate(e)
-    if ashfall.data.insideTent then
+    if isPlayerOutdoorSheltered() then
         if isRainLoopSoundPlaying() then
             playTentSound()
         else
@@ -135,7 +239,7 @@ end
 local function onCOC()
     sounds.removeImmediate { module = moduleName }
     -- Prevent playing tracks for a little while in order to allow
-    -- ashfall.data.insideTent to update after a cell change 
+    -- isPlayerOutdoorSheltered() to update after a cell change 
     timerInProgress = true
     timer.start{
         iterations = 1,
@@ -146,7 +250,7 @@ local function onCOC()
     }
 end
 
-if ashfall and config.ashfallTentSounds then
+if config.shelterSounds then
     WtC = tes3.worldController.weatherController
     event.register("simulate", onSimulate, {priority=-234})
     event.register("cellChanged", onCOC, {priority=-160})

--- a/defaults.lua
+++ b/defaults.lua
@@ -47,6 +47,7 @@ return {
     interiorMusic = false,
     windSounds = true,
     rainSounds = true,
+    ashfallTentSounds = true,
     disabledTaverns = {},
     windVol = 110,
     playInteriorWind = true,

--- a/defaults.lua
+++ b/defaults.lua
@@ -47,7 +47,7 @@ return {
     interiorMusic = false,
     windSounds = true,
     rainSounds = true,
-    ashfallTentSounds = true,
+    shelterSounds = true,
     disabledTaverns = {},
     windVol = 110,
     playInteriorWind = true,

--- a/i18n/en.lua
+++ b/i18n/en.lua
@@ -18,7 +18,6 @@ this.messages = {
 	mainLabel = "by tewlwolow.\nLua-based sound overhaul.",
 
 	WtS = "Requires Watch the Skies.",
-	Ashfall = "Requires Ashfall.",
 
 	settings = "Settings",
 	default = "Default",
@@ -105,7 +104,7 @@ this.messages = {
 	miscDesc = "Plays various miscellaneous sounds.",
 	rainSounds = "Enable variable rain sounds per max particles?",
 	windSounds = "Enable variable wind sounds per clouds speed?",
-	ashfallTentSounds = "Enable interior rain sounds while sheltered inside mobile tents?",
+	shelterSounds = "Enable interior rain sounds when sheltered inside portable tents or covered by an overhang?",
 	playInteriorWind = "Enable wind sounds in interiors? This means the last exterior loop will play on each door and window leading to an exterior.",
 	windVol = "Changes % volume for wind sounds.",
 	playSplash = "Enable splash sounds when going underwater and back to surface?",

--- a/i18n/en.lua
+++ b/i18n/en.lua
@@ -18,6 +18,7 @@ this.messages = {
 	mainLabel = "by tewlwolow.\nLua-based sound overhaul.",
 
 	WtS = "Requires Watch the Skies.",
+	Ashfall = "Requires Ashfall.",
 
 	settings = "Settings",
 	default = "Default",
@@ -104,6 +105,7 @@ this.messages = {
 	miscDesc = "Plays various miscellaneous sounds.",
 	rainSounds = "Enable variable rain sounds per max particles?",
 	windSounds = "Enable variable wind sounds per clouds speed?",
+	ashfallTentSounds = "Enable interior rain sounds while sheltered inside mobile tents?",
 	playInteriorWind = "Enable wind sounds in interiors? This means the last exterior loop will play on each door and window leading to an exterior.",
 	windVol = "Changes % volume for wind sounds.",
 	playSplash = "Enable splash sounds when going underwater and back to surface?",

--- a/i18n/fr.lua
+++ b/i18n/fr.lua
@@ -31,7 +31,6 @@ this.messages = {
 	mainLabel = "par tewlwolow.\nAmélioration audio utilisant MWSE.",
 
 	WtS = "Nécessite Watch the Skies.",
-	Ashfall = "Nécessite Ashfall",
 
 	settings = "Paramètres",
 	default = "Par défaut",
@@ -118,7 +117,7 @@ this.messages = {
 	miscDesc = "Joue des sons additionnels divers.",
 	rainSounds = "Activer les sons variables de la pluie en fonction du nombre de particules ?",
 	windSounds = "Activer les sons variables du vent en fonction de la vitesse des nuages ?",
-	ashfallTentSounds = "Activer les sons de la pluie en intérieur à l'abri dans des tentes mobiles ?",
+	shelterSounds = "Activer les sons de la pluie en intérieur lorsque vous êtes abrité à l'intérieur de tentes portables ou couvert par un surplomb ?",
 	playInteriorWind = "Activer les sons de vent en intérieur ? Cela signifie que la dernière boucle extérieure en date sera jouée au niveau de chaque porte ou fenêtre menant à l'extérieur.",
 	windVol = "Change le % volume for wind sounds.",
 	playSplash = "Activer les sons d'éclaboussures en entrant et sortant de l'eau ?",

--- a/i18n/fr.lua
+++ b/i18n/fr.lua
@@ -31,6 +31,7 @@ this.messages = {
 	mainLabel = "par tewlwolow.\nAmélioration audio utilisant MWSE.",
 
 	WtS = "Nécessite Watch the Skies.",
+	Ashfall = "Nécessite Ashfall",
 
 	settings = "Paramètres",
 	default = "Par défaut",
@@ -117,6 +118,7 @@ this.messages = {
 	miscDesc = "Joue des sons additionnels divers.",
 	rainSounds = "Activer les sons variables de la pluie en fonction du nombre de particules ?",
 	windSounds = "Activer les sons variables du vent en fonction de la vitesse des nuages ?",
+	ashfallTentSounds = "Activer les sons de la pluie en intérieur à l'abri dans des tentes mobiles ?",
 	playInteriorWind = "Activer les sons de vent en intérieur ? Cela signifie que la dernière boucle extérieure en date sera jouée au niveau de chaque porte ou fenêtre menant à l'extérieur.",
 	windVol = "Change le % volume for wind sounds.",
 	playSplash = "Activer les sons d'éclaboussures en entrant et sortant de l'eau ?",

--- a/mcm.lua
+++ b/mcm.lua
@@ -352,8 +352,8 @@ pageMisc:createYesNoButton {
 	variable = registerVariable("rainSounds"),
 }
 pageMisc:createYesNoButton {
-	label = string.format("%s %s", messages.ashfallTentSounds, messages.Ashfall),
-	variable = registerVariable("ashfallTentSounds"),
+	label = string.format("%s %s", messages.shelterSounds),
+	variable = registerVariable("shelterSounds"),
 }
 pageMisc:createYesNoButton {
 	label = string.format("%s %s", messages.windSounds, messages.WtS),

--- a/mcm.lua
+++ b/mcm.lua
@@ -352,6 +352,10 @@ pageMisc:createYesNoButton {
 	variable = registerVariable("rainSounds"),
 }
 pageMisc:createYesNoButton {
+	label = string.format("%s %s", messages.ashfallTentSounds, messages.Ashfall),
+	variable = registerVariable("ashfallTentSounds"),
+}
+pageMisc:createYesNoButton {
 	label = string.format("%s %s", messages.windSounds, messages.WtS),
 	variable = registerVariable("windSounds"),
 }

--- a/soundBuilder.lua
+++ b/soundBuilder.lua
@@ -180,6 +180,14 @@ local function buildWeatherSounds()
 	objectId = "tew_t_rainheavy"
 	createSound(objectId, filename)
 
+	filename = soundDir .. wDir .. "\\ten\\rm.wav"
+    objectId = "tew_at_rainmedium"
+    createSound(objectId, filename)
+
+	filename = soundDir .. wDir .. "\\ten\\rh.wav"
+    objectId = "tew_at_rainheavy"
+    createSound(objectId, filename)
+
 	filename, objectId = nil, nil
 end
 

--- a/soundBuilder.lua
+++ b/soundBuilder.lua
@@ -181,15 +181,15 @@ local function buildWeatherSounds()
 	createSound(objectId, filename)
 
 	filename = soundDir .. wDir .. "\\ten\\rl.wav"
-    objectId = "tew_at_rainlight"
+    objectId = "tew_sh_rainlight"
     createSound(objectId, filename)
 
 	filename = soundDir .. wDir .. "\\ten\\rm.wav"
-    objectId = "tew_at_rainmedium"
+    objectId = "tew_sh_rainmedium"
     createSound(objectId, filename)
 
 	filename = soundDir .. wDir .. "\\ten\\rh.wav"
-    objectId = "tew_at_rainheavy"
+    objectId = "tew_sh_rainheavy"
     createSound(objectId, filename)
 
 	filename, objectId = nil, nil

--- a/soundBuilder.lua
+++ b/soundBuilder.lua
@@ -180,6 +180,10 @@ local function buildWeatherSounds()
 	objectId = "tew_t_rainheavy"
 	createSound(objectId, filename)
 
+	filename = soundDir .. wDir .. "\\ten\\rl.wav"
+    objectId = "tew_at_rainlight"
+    createSound(objectId, filename)
+
 	filename = soundDir .. wDir .. "\\ten\\rm.wav"
     objectId = "tew_at_rainmedium"
     createSound(objectId, filename)

--- a/sounds.lua
+++ b/sounds.lua
@@ -77,7 +77,7 @@ this.interiorWeather = {
 		[7] = nil,
 		[9] = nil
 	},
-	["ate"] = {
+	["she"] = {
 		[4] = nil,
 		[5] = nil,
 		[6] = nil,
@@ -108,7 +108,7 @@ local modules = {
 		old = nil,
 		new = nil
 	},
-	["ashfallTent"] = {
+	["shelter"] = {
 		old = nil,
 		new = nil
 	}
@@ -310,7 +310,7 @@ function this.remove(options)
 		debugLog("Old track not playing.")
 	end
 
-	-- Workaround to prevent repeating fadeOut for ashfallTent module
+	-- Workaround to prevent repeating fadeOut for shelter module
 	if options.clearNewTrack then modules[options.module].new = nil end
 
 	if modules[options.module].new
@@ -383,13 +383,13 @@ local function getTrack(options)
 			debugLog("Got cold type.")
 			table = this.cold
 		end
-	elseif options.module == "ashfallTent" then
-		debugLog("Got ashfall tent sounds module.")
+	elseif options.module == "shelter" then
+		debugLog("Got shelter module.")
 		debugLog("Got interior type: "..options.type)
-		local ateTrack = this.interiorWeather[options.type][options.weather]
-		if ateTrack then
-			debugLog("Got track: " .. ateTrack.id)
-			return ateTrack
+		local shelterTrack = this.interiorWeather[options.type][options.weather]
+		if shelterTrack then
+			debugLog("Got track: " .. shelterTrack.id)
+			return shelterTrack
 		else
 			debugLog("No track found.")
 			return


### PR DESCRIPTION
Hey!

Just a little addition to AURA if I may. New Misc option to add interior rain sounds when sheltered inside a mobile/portable tent.

~~Currently only Ashfall tents supported... because easier to implement heh~~

Ashfall tents as well as vanilla game tents and overhangs supported now!

What it does:

1. Checks whether you are inside or outside a tent (or covered by an overhang)
2. Adds appropriate interior rain sound when inside (or under) such a shelter, depending on rain type
3. Removes sound when you exit the shelter

Cool features:

- Different Fade in / Fade out duration whether you are entering or exiting the tent - **wow**!
- ~~Playing or stopping an interior rain loop track (almost) matches starting and ending of weather transitions - **double wow**!~~ Now strictly monitoring `rainLoopSound`, no more jumping through hoops. --

Currently only using existing assets `"\\ten\\rm.wav"` and `"\\ten\\rh.wav"`. Reason for this being these 2 tracks are loud enough to be heard properly against the already running `rainLoopSound`. Actually I wanted to do something cool like fade out and lower the `rainLoopSound` volume by like 25% when inside the tent and keep it like that until you exit the tent again. Alas, during my investigations I found out that for some unknown reason, `tes3.adjustSoundVolume()` can't handle `rainLoopSound` tracks.

Update: Also added `"\\ten\\rl.wav"`. Goes really well with light rain 😉 
