### PR TITLE
rain-on-statics v3

### DIFF
--- a/Misc/rainOnStatics.lua
+++ b/Misc/rainOnStatics.lua
@@ -8,6 +8,9 @@ local playerRef
 local staticsCache = {}
 
 local currentShelter
+local lastCell
+local lastCellStaticsAmount
+
 local TICK = 0.1
 
 local rainyStatics = {
@@ -178,8 +181,14 @@ local function clearCache()
 end
 
 local function populateCache()
-	debugLog("Commencing dump!")
 	local cell = tes3.getPlayerCell()
+	if (cell == lastCell) and (lastCellStaticsAmount == 0) then
+		-- No need to keep iterating over cell references
+		-- if we know that there are none in it that could
+		-- be added to our staticsCache.
+		return
+	end
+	debugLog("Commencing dump!")
 	for ref in cell:iterateReferences() do
 		-- We are interested in both statics and activators
 		if (ref.object.objectType == tes3.objectType.static)
@@ -196,6 +205,8 @@ local function populateCache()
 		:: continue ::
 	end
 	debugLog("staticsCache now holds " .. #staticsCache .. " statics.")
+	lastCell = cell
+	lastCellStaticsAmount = #staticsCache
 end
 
 local function tick()

--- a/Misc/rainOnStatics.lua
+++ b/Misc/rainOnStatics.lua
@@ -1,133 +1,267 @@
 local sounds = require("tew.AURA.sounds")
 local common = require("tew.AURA.common")
-
-
 local debugLog = common.debugLog
+local fader = require("tew.AURA.fader")
 
 local WtC
-
+local playerRef
 local staticsCache = {}
 
-local allowedWeathers = {
-	["Rain"] = true,
-	["Thunerstorm"] = true
-}
-
--- Map between weather types, rain types and sound id --
-local rainLoops = {
-    ["Rain"] = sounds.interiorWeather["ten"][4],
-    ["Thunderstorm"] = sounds.interiorWeather["ten"][5]
-}
+local currentShelter
+local TICK = 0.1
 
 local rainyStatics = {
 	"tent",
-	"guarskin",
-	"skin",
+	"skin", -- skin matches guarskin, bearskin
 	"fabric",
 	"awning",
 	"overhang",
-	"hilltent",
-	"banner"
+	"banner",
+	"marketstand", -- relevant Tamriel_Data and OAAB_Data assets
 }
 
+local shelterStatics = {
+	"tent",
+	"overhang",
+	"awning",
+}
 
-local function resolveStatics(cell)
-	local statics = {}
-	for stat in cell:iterateReferences(tes3.objectType.static) do
-		for _, pattern in pairs(rainyStatics) do
-			if string.find(stat.object.id:lower(), pattern) then
-				table.insert(statics, #statics+1, stat)
-			end
-		end
-	end
-	return statics
+local blockedStatics = {
+	"bannerpost",
+	"bannerhanger", -- Tamriel_Data
+	"ex_ashl_banner", -- vanilla bannerpost
+}
+
+local tracks = {
+	"tew_t_rainlight",
+	"tew_t_rainmedium",
+	"tew_t_rainheavy",
+}
+
+local function isRainLoopSoundPlaying()
+    if WtC.currentWeather.rainLoopSound
+	and WtC.currentWeather.rainLoopSound:isPlaying() then
+        return true
+    else
+        return false
+    end
 end
 
--- Set proper rain sounds --
-local function onConditionsChanged()
-
-	local cell = tes3.getPlayerCell()
-	local weather
-	if WtC.nextWeather then
-		weather = WtC.nextWeather
-	else
-		weather = WtC.currentWeather
+local function removeSoundFromRef(ref)
+	for _, v in ipairs(tracks) do
+		if tes3.getSoundPlaying{
+			sound = v,
+			reference = ref
+		} then
+			debugLog("Track " .. v .. " playing on ref " .. tostring(ref) .. ", now removing it.")
+			tes3.removeSound{
+				sound = v,
+				reference = ref
+			}
+		end
 	end
-	local weatherName = weather.name
+end
 
-	if not (allowedWeathers[weatherName]) or not (cell.isOrBehavesAsExterior) then
-		if staticsCache then
-			for _, list in ipairs(staticsCache) do
-				for _, stat in ipairs(list) do
-					if tes3.getSoundPlaying{
-						sound = sounds.interiorWeather["ten"][4],
-						reference = stat
-					} then
-						tes3.removeSound{
-							sound = sounds.interiorWeather["ten"][4],
-							reference = stat
-						}
-					end
-					if tes3.getSoundPlaying{
-						sound = sounds.interiorWeather["ten"][5],
-						reference = stat
-					} then
-						tes3.removeSound{
-							sound = sounds.interiorWeather["ten"][5],
-							reference = stat
-						}
-					end
-					stat.tempData.tew = nil
-				end
+local function findMatch(patternsTable, objId)
+	for _, pattern in pairs(patternsTable) do
+		if string.find(objId, pattern) then
+			return true
+		end
+	end
+	return false
+end
+
+local function getTrackPlaying(ref)
+	local track = nil
+	for _, v in ipairs(tracks) do
+		if tes3.getSoundPlaying{
+			sound = v,
+			reference = ref
+		} then
+			track = v
+		end
+	end
+	return track
+end
+
+local function addSound(ref)
+	local sound = sounds.interiorWeather["ten"][WtC.currentWeather.index]
+	if not sound then return end
+	local playerPos = tes3.player.position:copy()
+	local refPos = ref.position:copy()
+	local objId = ref.object.id:lower()
+
+	if fader.isRunning() then return end
+
+	-- Check if sheltered by current ref.
+	-- If we are, then crossFade from current ref to playerRef.
+
+	if (not currentShelter)
+	and (findMatch(shelterStatics, objId))
+	and (playerPos:distance(refPos) < 190)
+	and (common.isPlayerShelteredByRef(ref)) then
+		debugLog("Player sheltered.")
+		if tes3.getSoundPlaying{sound = sound, reference = playerRef} then
+			-- We are sheltered and sound is playing on player ref.
+			debugLog("[sheltered] Sound playing on playerRef.")
+			return
+		end
+		if tes3.getSoundPlaying{sound = sound, reference = ref} then
+			debugLog("[sheltered] Sound playing on shelter ref. Running crossFade.")
+			fader.crossFade{
+				trackOld = sound,
+				trackNew = sound,
+				refOld = ref,
+				refNew = playerRef,
+				fadeInStep = 0.13,
+				fadeOutStep = 0.035,
+			}
+			currentShelter = ref
+			return
+		end
+	end
+
+	-- Check if not sheltered anymore by current ref.
+	-- If we're not, then crossFade from playerRef to current ref.
+
+	if (currentShelter == ref)
+	and (playerPos:distance(refPos) >= 70)
+	and (not common.isPlayerShelteredByRef(ref)) then
+		if fader.isRunning() then return end
+		if tes3.getSoundPlaying{sound = sound, reference = playerRef} then
+			debugLog("[not sheltered] Sound playing on playerRef. Running crossFade.")
+			fader.crossFade{
+				trackOld = sound,
+				trackNew = sound,
+				refOld = playerRef,
+				refNew = ref,
+				fadeInStep = 0.13,
+				fadeOutStep = 0.055,
+			}
+			currentShelter = nil
+			return
+		end
+	end
+
+	-- If current ref isn't a viable shelter, then just add ref sound.
+
+	if (not currentShelter)
+		and (not tes3.getSoundPlaying{sound = sound, reference = ref})
+		and (playerPos:distance(refPos) < 800) then
+		debugLog("Adding sound " .. sound.id .. " for ---> " .. objId)
+		tes3.playSound{ sound = sound, reference = ref, loop = true }
+	end
+end
+
+local function clearCache()
+	if #staticsCache > 0 then
+		debugLog("Clearing staticsCache.")
+		for _, ref in ipairs(staticsCache) do
+			removeSoundFromRef(ref)
+			staticsCache[_] = nil
+		end
+	end
+	if currentShelter then
+		local playerRefSound = getTrackPlaying(playerRef)
+		if playerRefSound then
+			debugLog(tostring(playerRefSound) .. " playing on playerRef. Running fadeOut.")
+			fader.fadeOut({
+				reference = playerRef,
+				track = playerRefSound,
+				fadeStep = 0.050,
+			})
+		else
+			debugLog("Sound not playing on playerRef.")
+		end
+		currentShelter = nil
+	end
+end
+
+local function populateCache()
+	debugLog("Commencing dump!")
+	local cell = tes3.getPlayerCell()
+	for ref in cell:iterateReferences() do
+		-- We are interested in both statics and activators
+		if (ref.object.objectType == tes3.objectType.static)
+			or (ref.object.objectType == tes3.objectType.activator) then
+			if findMatch(blockedStatics, ref.object.id:lower()) then
+				debugLog("Skipping blocked static: " .. tostring(ref))
+				goto continue
+			end
+			if findMatch(rainyStatics, ref.object.id:lower()) then
+				debugLog("Adding static " .. tostring(ref) .. " to cache. Not yet playing.")
+				table.insert(staticsCache, #staticsCache+1, ref)
 			end
 		end
+		:: continue ::
+	end
+	debugLog("staticsCache now holds " .. #staticsCache .. " statics.")
+end
+
+local function tick()
+	if fader.isRunning() then
+		debugLog("Fader is running. Returning.")
 		return
 	end
-
-    local sound = rainLoops[weatherName]
-
-
-	local statics = resolveStatics(cell)
-	table.insert(staticsCache, #staticsCache+1, statics)
-
-	if statics then
-		local playerPos = tes3.player.position:copy()
-		for _, stat in pairs(statics) do
-			if not stat.tempData.tew then
-				stat.tempData.tew = {}
-			end
-			if not stat.tempData.tew.staticRain
-			and playerPos:distance(stat.position:copy()) < 800 then
-				tes3.playSound {
-					sound = sound,
-					reference = stat,
-					loop = true,
-					pitch = 1.7,
-					volume = 1.0
-				}
-				debug.log(stat.id)
-				stat.tempData.tew.staticRain = true
-			end
+	if isRainLoopSoundPlaying() then
+		if #staticsCache == 0 then
+			populateCache()
 		end
+		for _, ref in ipairs(staticsCache) do
+			addSound(ref)
+		end
+	else
+		if #staticsCache > 0 then
+			debugLog("Invoking clearCache.")
+			clearCache()
+		end
+	end
+end
+
+local function onCOC(e)
+	debugLog("Cell changed.")
+	if e.previousCell then
+		debugLog("Got previousCell.")
+		if e.cell ~= e.previousCell then
+			debugLog("New cell. Clearing cache...")
+			removeSoundFromRef(playerRef)
+			currentShelter = nil
+			clearCache()
+		end
+	else
+		debugLog("No previousCell.")
 	end
 end
 
 local function runTimer()
+	debugLog("Starting timer.")
+	playerRef = tes3.mobilePlayer.reference
 	timer.start{
-		type=timer.simulate,
+		type = timer.simulate,
 		duration = 1,
 		iterations = -1,
-		callback = onConditionsChanged
+		callback = tick
 	}
+end
+
+local function onWeatherTransitionFinished()
+	debugLog("[weatherTransitionFinished] Invoking clearCache.")
+	clearCache()
+end
+
+local function onWeatherChangedImmediate()
+	debugLog("[weatherChangedImmediate] Immediately removing player ref sound.")
+	removeSoundFromRef(playerRef)
+	currentShelter = nil
+	debugLog("[weatherChangedImmediate] Invoking clearCache.")
+	clearCache()
 end
 
 WtC = tes3.worldController.weatherController
 
-event.register("loaded", onConditionsChanged, { priority = -300 })
+event.register("load", clearCache, { priority = -150 })
 event.register("loaded", runTimer, { priority = -300 })
-event.register("cellChanged", onConditionsChanged, { priority = -300 })
-event.register("weatherChangedImmediate", onConditionsChanged, { priority = -300 })
-event.register("weatherTransitionImmediate", onConditionsChanged, { priority = -300 })
-event.register("weatherTransitionStarted", onConditionsChanged, { priority = -300 })
-event.register("weatherTransitionFinished", onConditionsChanged, { priority = -300 })
-
+event.register("cellChanged", onCOC, { priority = -150 })
+event.register("weatherTransitionFinished", onWeatherTransitionFinished, { priority = -250 })
+event.register("weatherChangedImmediate", onWeatherChangedImmediate, { priority = -250 })
+event.register("weatherTransitionImmediate", onWeatherChangedImmediate, { priority = -250 })

--- a/common.lua
+++ b/common.lua
@@ -110,4 +110,72 @@ function this.getWindoors(cell)
 	end
 end
 
+function this.cellIsInterior()
+    local cell = tes3.getPlayerCell()
+    if cell and
+        cell.isInterior and
+        (not cell.behavesAsExterior) then
+        return true
+    else
+        return false
+    end
+end
+
+function this.isPlayerShelteredByRef(targetRef)
+
+	-- Checks if player is sheltered inside
+	-- or underneath the given ref.
+    -- Returns true if rayTest result matches
+    -- targetRef arg, or false otherwise.
+
+    if this.cellIsInterior() then
+        return false
+    end
+
+    local sheltered = false
+    local match = false
+    local reference = tes3.player
+
+	this.debugLog("RayTesting if sheltered by static: " .. tostring(targetRef))
+
+    local height = reference.object.boundingBox
+        and reference.object.boundingBox.max.z or 0
+
+    local results = tes3.rayTest{
+        position = {
+            reference.position.x,
+            reference.position.y,
+            reference.position.z + (height/2)
+        },
+        direction = {0, 0, 1},
+        findAll = true,
+        maxDistance = 5000,
+        ignore = {reference},
+        useBackTriangles = true,
+    }
+    if results then
+        for _, result in ipairs(results) do
+            match = false
+            if result and result.reference and result.reference.object then
+                sheltered =
+                    ( result.reference.object.objectType == tes3.objectType.static or
+                    result.reference.object.objectType == tes3.objectType.activator ) == true
+				if result.reference.object.id:lower() == targetRef.object.id:lower() then
+					match = true
+				end
+                if sheltered == true then
+                    break
+                end
+            end
+        end
+    end
+	if (sheltered and match) then
+		this.debugLog("RayTest matched for " .. tostring(targetRef))
+		return true
+	else
+		this.debugLog("RayTest did not match for " .. tostring(targetRef))
+		return false
+	end
+end
+
 return this

--- a/fader.lua
+++ b/fader.lua
@@ -1,0 +1,155 @@
+local this = {}
+
+--local modversion = require("tew.AURA.version")
+--local version = modversion.version
+local common = require("tew.AURA.common")
+local debugLog = common.debugLog
+
+local STEP = 0.015
+local TICK = 0.1
+local MAX = 1
+local MIN = 0
+local fadeTimer
+local crossFadeTimer
+
+this.crossFadeRunning = false
+this.fadeRunning = false
+
+local function playWithZeroVolume(track, ref)
+    debugLog("Playing with zero volume: " .. tostring(track) .. "->" .. tostring(ref))
+    tes3.playSound {
+        sound = track,
+        loop = true,
+        reference = ref,
+        volume = MIN,
+        pitch = MAX
+    }
+end
+
+
+local function parse(options)
+    local ref = options.reference or tes3.mobilePlayer.reference
+    local track = options.track
+    local fadeStep = options.fadeStep
+    local fadeType = options.fadeType
+    local volume = options.volume or MAX
+    local currentVolume
+
+    local TIME = TICK * volume / fadeStep
+	local ITERS = math.ceil(volume / fadeStep)
+
+    if not track then
+        debugLog("No track to fade " .. fadeType .. ". Returning.")
+        return
+    end
+
+    if fadeType == "in" then
+        playWithZeroVolume(track, ref)
+        currentVolume = MIN
+    else
+        currentVolume = MAX
+    end
+
+    if (not tes3.getSoundPlaying{sound = track, reference = ref}) then
+        debugLog("Track not playing, cannot fade " .. fadeType .. ". Returning.")
+        return
+    end
+
+    debugLog("Running fade " .. fadeType .. " for: " .. tostring(track))
+
+    local function fader()
+        if fadeType == "in" then
+            currentVolume = currentVolume + fadeStep
+        else
+            currentVolume = currentVolume - fadeStep
+        end
+        if currentVolume < 0 then currentVolume = 0 end
+        if currentVolume > 1 then currentVolume = 1 end
+    
+        tes3.adjustSoundVolume{sound = track, volume = currentVolume, reference = ref}
+
+        debugLog(string.format("Adjusting volume %s: %s -> %s | %.3f", fadeType, tostring(track), tostring(ref), currentVolume))
+    end
+
+    this.fadeRunning = true
+
+    timer.start{
+        iterations = ITERS,
+        duration = TICK,
+        callback = fader
+    }
+
+    fadeTimer = timer.start{
+        iterations = 1,
+        duration = TIME + 0.1,
+        callback = function()
+            if fadeType == "out" then
+                if tes3.getSoundPlaying{sound = track, reference = ref} then
+                    tes3.removeSound{sound = track, reference = ref}
+                end
+            end
+            debugLog(string.format("Fade %s for %s finished in %.3f s.", fadeType, tostring(track), TIME))
+            this.fadeRunning = false
+        end
+    }
+end
+
+function this.isRunning()
+    return this.crossFadeRunning or this.fadeRunning
+end
+
+function this.getTimeLeft()
+    if crossFadeTimer and (crossFadeTimer.state == 0) then
+        return crossFadeTimer.timeLeft
+    elseif fadeTimer and (fadeTimer.state == 0) then
+        return fadeTimer.timeLeft
+    else
+        return 0
+    end
+end
+
+function this.fadeIn(options)
+    options.fadeType = "in"
+    parse(options)
+end
+
+function this.fadeOut(options)
+    options.fadeType = "out"
+    parse(options)
+end
+
+function this.crossFade(options)
+    local trackOld = options.trackOld
+    local trackNew = options.trackNew
+    local refOld = options.refOld
+    local refNew = options.refNew
+    local fadeInStep = options.fadeInStep or STEP
+    local fadeOutStep = options.fadeOutStep or STEP
+    local volume = options.volume or MAX
+    local TIME = (TICK*volume/fadeInStep) + (TICK*volume/fadeOutStep)
+
+    debugLog("Running crossfade for: " .. tostring(trackOld) .. ", " .. tostring(trackNew))
+    debugLog("Crossfading from old ref " .. tostring(refOld) .. " to new ref " .. tostring(refNew))
+    
+    this.crossFadeRunning = true
+    this.fadeOut({
+        track = trackOld,
+        reference = refOld,
+        fadeStep = fadeOutStep,
+    })
+    this.fadeIn({
+        track = trackNew,
+        reference = refNew,
+        fadeStep = fadeInStep,
+    })
+    crossFadeTimer = timer.start{
+        iterations = 1,
+        duration = TIME + 0.2,
+        callback = function()
+            this.crossFadeRunning = false
+        end
+    }
+end
+
+
+return this


### PR DESCRIPTION
Ok! 😄  This does exactly what https://github.com/tewlwolow/AURA/pull/2 does, with the added benefit of checking if a nearby static is a viable shelter that the player could crawl under or go into. Upon which, the sound playing on that ref will fade out (and be completely removed) and then the same exact sound will fade in for the player ref. The reverse of this happens when you leave the shelter.

The `rayTest` check runs only if the distance between player and the shelter static is small enough, and it only checks for 3 types of statics (as declared in `shelterStatics`).

No issues as of yet.