### PR TITLE
Rain on statics v4

### DIFF
--- a/Misc/rainOnStatics.lua
+++ b/Misc/rainOnStatics.lua
@@ -3,28 +3,64 @@ local common = require("tew.AURA.common")
 local debugLog = common.debugLog
 local fader = require("tew.AURA.fader")
 
+local soundData = {
+	["tew_t_rainlight"] = {
+		[4] = {
+			volume = 1.0,
+			pitch = 1.0
+		},
+		[5] = {
+			volume = 1.0,
+			pitch = 1.0
+		},
+	},
+	["tew_t_rainmedium"] = {
+		[4] = {
+			volume = 0.7,
+			pitch = 1.0
+		},
+		[5] = {
+			volume = 0.8,
+			pitch = 1.0
+		},
+	},
+	["tew_t_rainheavy"] = {
+		[4] = {
+			volume = 0.7,
+			pitch = 1.0
+		},
+		[5] = {
+			volume = 0.8,
+			pitch = 1.0
+		},
+	},
+}
+
 local WtC
+local mainTimer
 local playerRef
+local playingBlocked
 local staticsCache = {}
+local currentShelter = {}
 
-local currentShelter
-local lastCell
-local lastCellStaticsAmount
-
-local TICK = 0.1
+local INTERVAL = 0.5 -- The lower this value, the snappier the fades
 
 local rainyStatics = {
+	"flag",
 	"tent",
-	"skin", -- skin matches guarskin, bearskin
+	"skin",
+	"shed", -- sheds are generally made out of wood, but so are some awnings
 	"fabric",
 	"awning",
-	"overhang",
 	"banner",
+	"_ban_", -- also banner
+	"overhang",
 	"marketstand", -- relevant Tamriel_Data and OAAB_Data assets
 }
 
 local shelterStatics = {
 	"tent",
+	"shed",
 	"overhang",
 	"awning",
 }
@@ -33,13 +69,83 @@ local blockedStatics = {
 	"bannerpost",
 	"bannerhanger", -- Tamriel_Data
 	"ex_ashl_banner", -- vanilla bannerpost
+	"flagpole",
+	"flagon", -- OAAB_Data
+	"aaa_refernce_flag", -- ?
+	"crushed",
+	"houseshed",
+	"setsky_x_shed", -- Tamriel_Data house addon
 }
 
-local tracks = {
-	"tew_t_rainlight",
-	"tew_t_rainmedium",
-	"tew_t_rainheavy",
+local rayTestIgnoreStatics = {
+	-- If a rayTest result matches either one of these, it will ignore it
+	-- and move on to the next result. e.g.: A banner can't be sheltered
+	-- by the railing it hangs from, or by another banner. (Inception!)
+	"signpost",
+	"railing",
+	"banner",
+	"_ban_",
+	"flag",
+	"hv_de_setveloth_beam_01", -- wood log used as a flag hanger in Heart of the Velothi - Gnisis
 }
+
+local exemptedFromShelteredTest = {
+	-- We want these to play a loop no matter where they are placed
+	-- in the world. That means no rayTest to check if they are
+	-- sheltered by another object.
+
+	-- RayTest results for awnings may return some false positives
+	-- e.g. only a small edge of an awning may happen to be sheltered
+	-- by a larger structure, and we shouln't really care about that.
+	-- (see ex_common_awning_wood_01 in vanilla Ebonheart)
+
+	"awning",
+
+	-- A portable tent can be tricky to deal with because
+	-- for instance if placed under a leafless tree, then
+	-- isRefSheltered() is likely to return true, but
+	-- technically speaking, rain should still be able to hit it.
+
+	--"ashfall_tent",
+}
+
+local function isRelevantRef(ref)
+	-- We are interested in both statics and activators. Also checking if
+	-- the ref is deleted because even if they are, they get caught by
+	-- cell:iterateReferences. As for ref.disabled, some mods disable
+	-- instead of delete refs, but it's actually useful if used correctly.
+	-- Gotta be extra careful not to call this function when a ref is
+	-- deactivated, because its "disabled" property will be true.
+	if ref.object
+	and ((ref.object.objectType == tes3.objectType.static) or
+		((ref.object.objectType == tes3.objectType.activator)))
+	and (not (ref.deleted or ref.disabled))
+	then
+		if common.findMatch(blockedStatics, ref.object.id:lower()) then
+			--debugLog("Skipping blocked static: " .. tostring(ref))
+			return false
+		end
+		if common.findMatch(rainyStatics, ref.object.id:lower()) then
+			return true
+		end
+	end
+	return false
+end
+
+local function removeSound(ref)
+	for trackName, arr in pairs(soundData) do
+		if tes3.getSoundPlaying{
+			sound = trackName,
+			reference = ref
+		} then
+			debugLog("Track " .. trackName .. " playing on ref " .. tostring(ref) .. ", now removing it.")
+			tes3.removeSound{
+				sound = trackName,
+				reference = ref
+			}
+		end
+	end
+end
 
 local function isRainLoopSoundPlaying()
     if WtC.currentWeather.rainLoopSound
@@ -50,163 +156,168 @@ local function isRainLoopSoundPlaying()
     end
 end
 
-local function removeSoundFromRef(ref)
-	for _, v in ipairs(tracks) do
-		if tes3.getSoundPlaying{
-			sound = v,
-			reference = ref
-		} then
-			debugLog("Track " .. v .. " playing on ref " .. tostring(ref) .. ", now removing it.")
-			tes3.removeSound{
-				sound = v,
-				reference = ref
-			}
-		end
+local function clearCurrentShelter()
+	if currentShelter.sound then
+		debugLog(currentShelter.sound.id .. " playing on playerRef. Running fadeOut.")
+		fader.fadeOut({
+			volume = currentShelter.volume,
+			reference = playerRef,
+			track = currentShelter.sound,
+			-- Here the duration can be higher than usual because this function
+			-- gets called on rare occasions. e.g. when you're chillaxing in a
+			-- tent waiting for the rain to stop, you want the fade out to be as
+			-- long as possible for extra immersion.
+			duration = 2,
+		})
+		currentShelter.ref = nil
+		currentShelter.sound = nil
+		currentShelter.volume = nil
 	end
 end
 
-local function findMatch(patternsTable, objId)
-	for _, pattern in pairs(patternsTable) do
-		if string.find(objId, pattern) then
-			return true
-		end
+local function addToCache(ref)
+	-- Resetting the timer on every add to kind of block it
+	-- from running while the cache is being populated.
+	if mainTimer then mainTimer:reset() end
+	if (common.cellIsInterior(ref.cell)) or (not isRelevantRef(ref)) then
+		return
 	end
-	return false
+	-- We only add a static to the cache if it's not already in there.
+	if not common.getIndex(staticsCache, ref) then
+		if not ref.tempData.tew then
+			ref.tempData.tew = {}
+		end
+		-- Adding (bool) sheltered temp data to every static in the cache
+		-- so that we later know whether to add a sound to it or not.
+		if not common.findMatch(exemptedFromShelteredTest, ref.object.id:lower()) then
+			ref.tempData.tew.sheltered = common.isRefSheltered{originRef = ref, ignoreList = rayTestIgnoreStatics}
+		end
+		table.insert(staticsCache, ref)
+		--debugLog("Added static " .. tostring(ref) .. " to cache. staticsCache: " .. #staticsCache)
+	else
+		--debugLog("Already in cache: " .. tostring(ref))
+	end
 end
 
-local function getTrackPlaying(ref)
-	local track = nil
-	for _, v in ipairs(tracks) do
-		if tes3.getSoundPlaying{
-			sound = v,
-			reference = ref
-		} then
-			track = v
-		end
+local function removeFromCache(ref)
+	-- Same logic as above, just backwards.
+	-- Make sure not to call isRelevantRef() here.
+
+	if mainTimer then mainTimer:reset() end
+	if (#staticsCache == 0) then return end
+
+	-- We need the ref's index for table.remove()
+	local index = common.getIndex(staticsCache, ref)
+	if not index then return end
+
+	removeSound(ref)
+	table.remove(staticsCache, index)
+	if (currentShelter.ref)
+	and (currentShelter.ref == ref) then
+		-- Immediately removing playerRef sound.
+		removeSound(playerRef)
+		currentShelter.ref = nil
+		currentShelter.volume = nil
+		currentShelter.sound = nil
 	end
-	return track
+	--debugLog("Removed static " .. tostring(ref) .. " from cache. staticsCache: " .. #staticsCache)
 end
 
-local function addSound(ref)
+-- Decide whether to add or remove sounds depending on weather type, distance to ref,
+-- whilst also checking if the player (or the ref itself) is sheltered.
+local function processRef(ref)
 	local sound = sounds.interiorWeather["ten"][WtC.currentWeather.index]
 	if not sound then return end
-	local playerPos = tes3.player.position:copy()
-	local refPos = ref.position:copy()
-	local objId = ref.object.id:lower()
+
+	if ref.tempData.tew then
+		if ref.tempData.tew.sheltered then
+			-- Current ref is sheltered by another object. Moving on.
+			return
+		end
+	end
 
 	if fader.isRunning() then return end
 
-	-- Check if sheltered by current ref.
-	-- If we are, then crossFade from current ref to playerRef.
+	local playerPos = tes3.player.position:copy()
+	local refPos = ref.position:copy()
+	local objId = ref.object.id:lower()
+	local volume = soundData[sound.id][WtC.currentWeather.index].volume
+	local pitch = soundData[sound.id][WtC.currentWeather.index].pitch
 
-	if (not currentShelter)
-	and (findMatch(shelterStatics, objId))
-	and (playerPos:distance(refPos) < 190)
-	and (common.isPlayerShelteredByRef(ref)) then
+	-- Check if sheltered by current ref.
+	-- If we are, then either fadeIn or crossFade.
+
+	if (not currentShelter.ref)
+	and (common.findMatch(shelterStatics, objId))
+	and (playerPos:distance(refPos) < 280)
+	and (common.isRefSheltered{targetRef = ref, ignoreList = rayTestIgnoreStatics}) then
 		debugLog("Player sheltered.")
-		if tes3.getSoundPlaying{sound = sound, reference = playerRef} then
-			-- We are sheltered and sound is playing on player ref.
-			debugLog("[sheltered] Sound playing on playerRef.")
-			return
-		end
-		if tes3.getSoundPlaying{sound = sound, reference = ref} then
+		if not tes3.getSoundPlaying{sound = sound, reference = ref} then
+			debugLog("[sheltered] Sound not playing on shelter ref. Running fadeIn.")
+			fader.fadeIn({
+				volume = volume,
+				pitch = pitch,
+				reference = playerRef,
+				track = sound,
+				duration = 0.7,
+			})
+		else
 			debugLog("[sheltered] Sound playing on shelter ref. Running crossFade.")
 			fader.crossFade{
+				volume = volume,
+				pitch = pitch,
 				trackOld = sound,
 				trackNew = sound,
 				refOld = ref,
 				refNew = playerRef,
-				fadeInStep = 0.13,
-				fadeOutStep = 0.035,
+				fadeInDuration = 0.5,
+				fadeOutDuration = 1,
 			}
-			currentShelter = ref
-			return
 		end
-	end
-
-	-- Check if not sheltered anymore by current ref.
-	-- If we're not, then crossFade from playerRef to current ref.
-
-	if (currentShelter == ref)
-	and (playerPos:distance(refPos) >= 70)
-	and (not common.isPlayerShelteredByRef(ref)) then
-		if fader.isRunning() then return end
-		if tes3.getSoundPlaying{sound = sound, reference = playerRef} then
-			debugLog("[not sheltered] Sound playing on playerRef. Running crossFade.")
-			fader.crossFade{
-				trackOld = sound,
-				trackNew = sound,
-				refOld = playerRef,
-				refNew = ref,
-				fadeInStep = 0.13,
-				fadeOutStep = 0.055,
-			}
-			currentShelter = nil
-			return
-		end
-	end
-
-	-- If current ref isn't a viable shelter, then just add ref sound.
-
-	if (not currentShelter)
-		and (not tes3.getSoundPlaying{sound = sound, reference = ref})
-		and (playerPos:distance(refPos) < 800) then
-		debugLog("Adding sound " .. sound.id .. " for ---> " .. objId)
-		tes3.playSound{ sound = sound, reference = ref, loop = true }
-	end
-end
-
-local function clearCache()
-	if #staticsCache > 0 then
-		debugLog("Clearing staticsCache.")
-		for _, ref in ipairs(staticsCache) do
-			removeSoundFromRef(ref)
-			staticsCache[_] = nil
-		end
-	end
-	if currentShelter then
-		local playerRefSound = getTrackPlaying(playerRef)
-		if playerRefSound then
-			debugLog(tostring(playerRefSound) .. " playing on playerRef. Running fadeOut.")
-			fader.fadeOut({
-				reference = playerRef,
-				track = playerRefSound,
-				fadeStep = 0.050,
-			})
-		else
-			debugLog("Sound not playing on playerRef.")
-		end
-		currentShelter = nil
-	end
-end
-
-local function populateCache()
-	local cell = tes3.getPlayerCell()
-	if (cell == lastCell) and (lastCellStaticsAmount == 0) then
-		-- No need to keep iterating over cell references
-		-- if we know that there are none in it that could
-		-- be added to our staticsCache.
+		-- Also add data to our new shelter so that we remove playerRef
+		-- sound correctly when clearCurrentShelter() gets called.
+		currentShelter.ref = ref
+		currentShelter.sound = sound
+		currentShelter.volume = volume
 		return
 	end
-	debugLog("Commencing dump!")
-	for ref in cell:iterateReferences() do
-		-- We are interested in both statics and activators
-		if (ref.object.objectType == tes3.objectType.static)
-			or (ref.object.objectType == tes3.objectType.activator) then
-			if findMatch(blockedStatics, ref.object.id:lower()) then
-				debugLog("Skipping blocked static: " .. tostring(ref))
-				goto continue
-			end
-			if findMatch(rainyStatics, ref.object.id:lower()) then
-				debugLog("Adding static " .. tostring(ref) .. " to cache. Not yet playing.")
-				table.insert(staticsCache, #staticsCache+1, ref)
-			end
-		end
-		:: continue ::
+
+	-- If we're currently sheltered, then keep checking until not we're not
+	-- sheltered anymore. If we're currently not sheltered, get rid of the
+	-- sound playing on playerRef. Here we can either crossFade (takes longer)
+	-- or just fadeOut. For now, just fadeOut and let a subsequent call to this
+	-- function add ref sound when the fade has finished.
+
+	if (currentShelter.ref == ref)
+	and (not common.isRefSheltered{originRef = playerRef, targetRef = ref}) then
+		debugLog("[not sheltered] Running fadeOut.")
+		fader.fadeOut({
+			volume = currentShelter.volume,
+			reference = playerRef,
+			track = currentShelter.sound,
+			duration = 0.8,
+		})
+		-- Since we're no longer sheltered, let's clear shelter data.
+		currentShelter.ref = nil
+		currentShelter.sound = nil
+		currentShelter.volume = nil
+		return
 	end
-	debugLog("staticsCache now holds " .. #staticsCache .. " statics.")
-	lastCell = cell
-	lastCellStaticsAmount = #staticsCache
+
+	-- If current ref isn't a viable shelter then just add ref sound.
+
+	if (not currentShelter.ref)
+		and (not tes3.getSoundPlaying{sound = sound, reference = ref})
+		and (playerPos:distance(refPos) < 800) then
+		debugLog("Adding sound " .. sound.id .. " for -> " .. objId)
+		tes3.playSound{
+			sound = sound,
+			reference = ref,
+			loop = true,
+			volume = volume,
+			pitch = pitch,
+		}
+	end
 end
 
 local function tick()
@@ -215,64 +326,93 @@ local function tick()
 		return
 	end
 	if isRainLoopSoundPlaying() then
-		if #staticsCache == 0 then
-			populateCache()
-		end
+		playingBlocked = false
 		for _, ref in ipairs(staticsCache) do
-			addSound(ref)
+			processRef(ref)
 		end
 	else
-		if #staticsCache > 0 then
-			debugLog("Invoking clearCache.")
-			clearCache()
+		if (not playingBlocked) and (#staticsCache > 0) then
+			-- Best not to clear the cache if it's not raining.
+			-- Just remove any sounds that are currently playing.
+			debugLog("Not raining. Removing any sounds that might be playing.")
+			for _, ref in ipairs(staticsCache) do
+				removeSound(ref)
+			end
+			clearCurrentShelter()
+			playingBlocked = true
+			debugLog("Playing is blocked.")
 		end
-	end
-end
-
-local function onCOC(e)
-	debugLog("Cell changed.")
-	if e.previousCell then
-		debugLog("Got previousCell.")
-		if e.cell ~= e.previousCell then
-			debugLog("New cell. Clearing cache...")
-			removeSoundFromRef(playerRef)
-			currentShelter = nil
-			clearCache()
-		end
-	else
-		debugLog("No previousCell.")
 	end
 end
 
 local function runTimer()
+	playerRef = tes3.player
 	debugLog("Starting timer.")
-	playerRef = tes3.mobilePlayer.reference
-	timer.start{
+	mainTimer = timer.start{
 		type = timer.simulate,
-		duration = 1,
+		duration = INTERVAL,
 		iterations = -1,
 		callback = tick
 	}
 end
 
-local function onWeatherTransitionFinished()
-	debugLog("[weatherTransitionFinished] Invoking clearCache.")
-	clearCache()
+local function refreshCache()
+	local cell = tes3.getPlayerCell()
+	debugLog("Commencing dump!")
+	for ref in cell:iterateReferences() do
+		addToCache(ref)
+	end
+	debugLog("staticsCache currently holds " .. #staticsCache .. " statics.")
 end
 
-local function onWeatherChangedImmediate()
-	debugLog("[weatherChangedImmediate] Immediately removing player ref sound.")
-	removeSoundFromRef(playerRef)
-	currentShelter = nil
-	debugLog("[weatherChangedImmediate] Invoking clearCache.")
-	clearCache()
+local function onCOC(e)
+	-- Since "referenceActivated" and "referenceDeactivated" events
+	-- occur before "cellChanged", at this point all statics should be
+	-- already resolved. Just making sure no rainy static has been left
+	-- behind when stepping into a new cell. Probably unnecessary, but
+	-- should cover some exotic edge cases.
+	debugLog("Cell changed.")
+	if e.previousCell then
+		debugLog("Got previousCell.")
+		if (not common.cellIsInterior(e.cell)) and (e.cell ~= e.previousCell) then
+			debugLog("New exterior cell. Refreshing cache.")
+			refreshCache()
+		end
+	else
+		-- previousCell should be nil when loading a game, no need to do
+		-- anything if that's the case.
+		debugLog("No previousCell.")
+	end
+end
+
+local function onWeatherTransitionFinished()
+	debugLog("[weatherTransitionFinished] Resetting all sounds.")
+	-- Remove all sounds and refresh the cache. If the weather has
+	-- changed, we want all the sounds that are currently playing
+	-- to update according to the new weather type. To be noted that
+	-- the cache stays the same. We don't remove any statics from it.
+	for _, ref in ipairs(staticsCache) do
+		removeSound(ref)
+	end
+	clearCurrentShelter()
+	refreshCache()
+end
+
+local function onReferenceActivated(e)
+	-- Here is where the initial resolve happens.
+	-- This event triggers before "cellChanged" and before "loaded".
+	addToCache(e.reference)
+end
+
+local function onReferenceDeactivated(e)
+	-- Same as above, but instead of adding, we remove from the cache.
+	removeFromCache(e.reference)
 end
 
 WtC = tes3.worldController.weatherController
 
-event.register("load", clearCache, { priority = -150 })
 event.register("loaded", runTimer, { priority = -300 })
-event.register("cellChanged", onCOC, { priority = -150 })
-event.register("weatherTransitionFinished", onWeatherTransitionFinished, { priority = -250 })
-event.register("weatherChangedImmediate", onWeatherChangedImmediate, { priority = -250 })
-event.register("weatherTransitionImmediate", onWeatherChangedImmediate, { priority = -250 })
+event.register("cellChanged", onCOC, { priority = -170 })
+event.register("weatherTransitionFinished", onWeatherTransitionFinished, { priority = -270 })
+event.register("referenceActivated", onReferenceActivated, { priority = -250 })
+event.register("referenceDeactivated", onReferenceDeactivated, { priority = -250 })

--- a/common.lua
+++ b/common.lua
@@ -111,7 +111,7 @@ function this.getWindoors(cell)
 end
 
 -- Pass me a table and an element and I'll tell you the index it's stored at --
-function getIndex(tab, elem)
+function this.getIndex(tab, elem)
 	local index = nil
 	for i, v in ipairs(tab) do
 		if (v == elem) then


### PR DESCRIPTION
Woah, this wasn't as easy as I thought 🤣  

Bunch of changes:

- Now monitoring `referenceActivated` and `referenceDeactivated` events. These events take precedence over `cell:iterateReferences`, this is how our `staticsCache` gets populated initially.

- In order to know whether a static is sheltered by another object, when it is added to the cache, a `rayTest` is performed on it and "sheltered" `tempData` is stored on that specific ref.

- Changed fader logic not to depend on a given `fadeStep` param, but on `duration`. Tell it how long you want the fade to be, and it will calculate the fade step internally. This is neat because the actual duration of the fade (`fadeDuration` in fader.lua) is no longer influenced by the `volume` that's passed to the fader.

- Added more static types.

- Lower volume for medium and heavy loops. Light was left unchanged. (because I can't hear it otherwise lol)

- Halved the main timer duration. Fades should be snappier now. Can be further tweaked by changing `INTERVAL` const.

- Lower fade duration in some instances. Switched from `crossFade` to just `fadeOut` when leaving a shelter (which should make the fades even faster).