### PR TITLE
Fix useLast for windoors in OA module

### DIFF
--- a/Ambient/Outdoor/outdoorMain.lua
+++ b/Ambient/Outdoor/outdoorMain.lua
@@ -53,6 +53,9 @@ local function weatherParser(options)
 		debugLog("Extreme weather detected.")
 		sounds.remove { module = moduleName, reference = ref, volume = OAvol }
 		return
+	else
+		debugLog("Uneligible weather detected. Returning.")
+		return
 	end
 end
 
@@ -223,8 +226,13 @@ local function cellCheck()
 			windoors = nil
 			windoors = common.getWindoors(cell)
 			if windoors ~= nil then
-				for _, windoor in ipairs(windoors) do
-					playInteriorBig(windoor, useLast)
+				for i, windoor in ipairs(windoors) do
+					sounds.removeImmediate { module = moduleName, reference = windoor }
+					if i == 1 then
+						playInteriorBig(windoor, useLast)
+					else
+						playInteriorBig(windoor, true)
+					end
 				end
 				interiorTimer:resume()
 			end


### PR DESCRIPTION
Use windSounds logic when passing `useLast` for windoors.

Previously, if `useLast` was set to `false` during a `cellCheck()`, OA module would pick a new sound not only for the first windoor, but for all windoors, and you could end up in a situation where each windoor would play a different sound.