### PR TITLE
Minor adjust tent sound values

### DIFF
--- a/Interior Weather/interiorWeatherMain.lua
+++ b/Interior Weather/interiorWeatherMain.lua
@@ -62,11 +62,11 @@ local soundData = {
 	},
     ["ten"] = {
         [4] = {
-            volume = 0.9,
+            volume = 1.0,
             pitch = 1.0
         },
         [5] = {
-            volume = 1.0,
+            volume = 0.9,
             pitch = 1.0
         },
         [6] = {


### PR DESCRIPTION
Since tent sounds for heavier rain can be easily heard compared to the light one, it would make sense to play the light rain track at a bit higher volume and the heavier one at a tad bit lower volume. ASMR ftw 🦻 