### PR TITLE
Sounds.lua overhaul

### DIFF
--- a/Interior Weather/interiorWeatherMain.lua
+++ b/Interior Weather/interiorWeatherMain.lua
@@ -15,7 +15,7 @@ local blockedWeathers = {
 	[8] = true,
 }
 
-local soundData = {
+local soundConfig = {
 	["sma"] = {
 		[4] = {
 			volume = 0.7,
@@ -156,8 +156,8 @@ local function playInteriorSmall(cell)
 	immediateParser {
 		weather = weather,
 		module  = moduleName,
-		volume  = soundData[interiorType][weather].volume * IWvol + volBoost,
-		pitch   = soundData[interiorType][weather].pitch,
+		volume  = soundConfig[interiorType][weather].volume * IWvol + volBoost,
+		pitch   = soundConfig[interiorType][weather].pitch,
 		type    = interiorType
 	}
 end
@@ -168,8 +168,8 @@ local function playInteriorBig(windoor, updateImmediate)
 	immediateParser {
 		weather   = weather,
 		module    = moduleName,
-		volume    = (soundData[interiorType][weather].volume * IWvol) - (0.005 * #windoors),
-		pitch     = soundData[interiorType][weather].pitch,
+		volume    = (soundConfig[interiorType][weather].volume * IWvol) - (0.005 * #windoors),
+		pitch     = soundConfig[interiorType][weather].pitch,
 		type      = interiorType,
 		immediate = updateImmediate,
 		reference = windoor,

--- a/Misc/rainOnStatics.lua
+++ b/Misc/rainOnStatics.lua
@@ -1,9 +1,9 @@
-local sounds = require("tew.AURA.sounds")
 local common = require("tew.AURA.common")
+local soundData = require("tew.AURA.soundData")
 local debugLog = common.debugLog
 local fader = require("tew.AURA.fader")
 
-local soundData = {
+local soundConfig = {
 	["tew_t_rainlight"] = {
 		[4] = {
 			volume = 1.0,
@@ -42,6 +42,7 @@ local playerRef
 local playingBlocked
 local staticsCache = {}
 local currentShelter = {}
+local moduleName = "rainOnStatics"
 
 local INTERVAL = 0.55 -- The lower this value, the snappier the fades
 
@@ -146,7 +147,7 @@ local function isRelevantRef(ref)
 end
 
 local function removeSound(ref)
-	for trackName, arr in pairs(soundData) do
+	for trackName in pairs(soundConfig) do
 		if tes3.getSoundPlaying{
 			sound = trackName,
 			reference = ref
@@ -173,6 +174,7 @@ local function clearCurrentShelter()
 	if currentShelter.sound then
 		debugLog(currentShelter.sound.id .. " playing on playerRef. Running fadeOut.")
 		fader.fadeOut({
+			module = moduleName,
 			volume = currentShelter.volume,
 			reference = playerRef,
 			track = currentShelter.sound,
@@ -181,6 +183,7 @@ local function clearCurrentShelter()
 			-- tent waiting for the rain to stop, you want the fade out to be as
 			-- long as possible for extra immersion.
 			duration = 2,
+			noBlockTracks = true,
 		})
 		currentShelter.ref = nil
 		currentShelter.sound = nil
@@ -192,7 +195,7 @@ local function addToCache(ref)
 	-- Resetting the timer on every add to kind of block it
 	-- from running while the cache is being populated.
 	if mainTimer then mainTimer:reset() end
-	if (common.cellIsInterior(ref.cell)) or (not isRelevantRef(ref)) then
+	if (not isRelevantRef(ref)) or (common.cellIsInterior(ref.cell)) then
 		return
 	end
 	-- We only add a static to the cache if it's not already in there.
@@ -239,7 +242,7 @@ end
 -- Decide whether to add or remove sounds depending on weather type, distance to ref,
 -- whilst also checking if the player (or the ref itself) is sheltered.
 local function processRef(ref)
-	local sound = sounds.interiorWeather["ten"][WtC.currentWeather.index]
+	local sound = soundData.interiorWeather["ten"][WtC.currentWeather.index]
 	if not sound then return end
 
 	if ref.tempData.tew then
@@ -249,13 +252,13 @@ local function processRef(ref)
 		end
 	end
 
-	if fader.isRunning() then return end
+	if fader.isRunning(moduleName) then return end
 
 	local playerPos = tes3.player.position:copy()
 	local refPos = ref.position:copy()
 	local objId = ref.object.id:lower()
-	local volume = soundData[sound.id][WtC.currentWeather.index].volume
-	local pitch = soundData[sound.id][WtC.currentWeather.index].pitch
+	local volume = soundConfig[sound.id][WtC.currentWeather.index].volume
+	local pitch = soundConfig[sound.id][WtC.currentWeather.index].pitch
 
 	-- Check if sheltered by current ref.
 	-- If we are, then either fadeIn or crossFade.
@@ -268,27 +271,37 @@ local function processRef(ref)
 		if not tes3.getSoundPlaying{sound = sound, reference = ref} then
 			debugLog("[sheltered] Sound not playing on shelter ref. Running fadeIn.")
 			fader.fadeIn({
+				module = moduleName,
 				volume = volume,
 				pitch = pitch,
 				reference = playerRef,
 				track = sound,
 				duration = 0.7,
+				noBlockTracks = true,
 			})
 		else
-			debugLog("[sheltered] Sound playing on shelter ref. Running crossFade.")
-			fader.crossFade{
+			debugLog("[sheltered] Sound playing on shelter ref. Running crossfade.")
+			fader.fadeOut({
+				module = moduleName,
 				volume = volume,
 				pitch = pitch,
-				trackOld = sound,
-				trackNew = sound,
-				refOld = ref,
-				refNew = playerRef,
-				fadeInDuration = 0.5,
-				fadeOutDuration = 1,
-			}
+				reference = ref,
+				track = sound,
+				duration = 0.7,
+				noBlockTracks = true,
+			})
+			fader.fadeIn({
+				module = moduleName,
+				volume = volume,
+				pitch = pitch,
+				reference = playerRef,
+				track = sound,
+				duration = 0.7,
+				noBlockTracks = true,
+			})
 		end
 		-- Also add data to our new shelter so that we remove playerRef
-		-- sound correctly when clearCurrentShelter() gets called.
+		-- sound correctly when player is no longer sheltered by this ref.
 		currentShelter.ref = ref
 		currentShelter.sound = sound
 		currentShelter.volume = volume
@@ -297,18 +310,20 @@ local function processRef(ref)
 
 	-- If we're currently sheltered, then keep checking until not we're not
 	-- sheltered anymore. If we're currently not sheltered, get rid of the
-	-- sound playing on playerRef. Here we can either crossFade (takes longer)
-	-- or just fadeOut. For now, just fadeOut and let a subsequent call to this
-	-- function add ref sound when the fade has finished.
+	-- sound playing on playerRef. Can choose between crossfade or fade out.
+	-- For now, just fade out and let a subsequent call to this function add
+	-- ref sound when the fade has finished.
 
 	if (currentShelter.ref == ref)
 	and (not common.isRefSheltered{originRef = playerRef, targetRef = ref}) then
 		debugLog("[not sheltered] Running fadeOut.")
 		fader.fadeOut({
+			module = moduleName,
 			volume = currentShelter.volume,
 			reference = playerRef,
 			track = currentShelter.sound,
 			duration = 0.8,
+			noBlockTracks = true,
 		})
 		-- Since we're no longer sheltered, let's clear shelter data.
 		currentShelter.ref = nil
@@ -334,7 +349,7 @@ local function processRef(ref)
 end
 
 local function tick()
-	if fader.isRunning() then
+	if fader.isRunning(moduleName) then
 		debugLog("Fader is running. Returning.")
 		return
 	end
@@ -347,13 +362,12 @@ local function tick()
 		if (not playingBlocked) and (#staticsCache > 0) then
 			-- Best not to clear the cache if it's not raining.
 			-- Just remove any sounds that are currently playing.
-			debugLog("Not raining. Removing any sounds that might be playing.")
+			debugLog("Not raining. Removing sounds.")
 			for _, ref in ipairs(staticsCache) do
 				removeSound(ref)
 			end
 			clearCurrentShelter()
 			playingBlocked = true
-			debugLog("Playing is blocked.")
 		end
 	end
 end
@@ -425,7 +439,7 @@ end
 WtC = tes3.worldController.weatherController
 
 event.register("loaded", runTimer, { priority = -300 })
-event.register("cellChanged", onCOC, { priority = -170 })
+--event.register("cellChanged", onCOC, { priority = -170 }) -- Seems like not needed after all. Let's minimize CPU workload.
 event.register("weatherTransitionFinished", onWeatherTransitionFinished, { priority = -270 })
 event.register("referenceActivated", onReferenceActivated, { priority = -250 })
 event.register("referenceDeactivated", onReferenceDeactivated, { priority = -250 })

--- a/Misc/rainSounds.lua
+++ b/Misc/rainSounds.lua
@@ -1,5 +1,5 @@
 local config = require("tew.AURA.config")
-local sounds = require("tew.AURA.sounds")
+local soundData = require("tew.AURA.soundData")
 local common = require("tew.AURA.common")
 
 local debugLog = common.debugLog
@@ -75,7 +75,7 @@ local function changeRainSounds()
 
     -- Also change interior rain sounds --
     if config.moduleInteriorWeather then
-        for interiorType, array in pairs(sounds.interiorWeather) do
+        for interiorType, array in pairs(soundData.interiorWeather) do
             array[4] = tes3.getSound(interiorRainLoops[interiorType][rainyType])
             array[5] = tes3.getSound(interiorRainLoops[interiorType][stormyType])
         end

--- a/Misc/windSounds.lua
+++ b/Misc/windSounds.lua
@@ -36,7 +36,6 @@ local function getWindType(cSpeed)
 end
 
 local function playWind(ref, useLast, vol, pitch)
-    debugLog("Wind type: " .. windType)
     if not vol then vol = windVol end
     sounds.play { module = moduleName, type = windType, volume = vol, pitch = pitch, reference = ref, last = useLast }
     windPlaying = true
@@ -48,7 +47,7 @@ local function updateInteriorBig()
     debugLog("Updating interior doors and windows.")
     local playerPos = tes3.player.position
     for _, windoor in ipairs(windoors) do
-        if playerPos:distance(windoor.position:copy()) > 900 -- Less then cutoff, just to be sure. Shouldn't be too jarring --
+        if playerPos:distance(windoor.position:copy()) < 1800 -- Less then cutoff, just to be sure. Shouldn't be too jarring --
             and windoor ~= nil then
             local windoorVol = (0.4 * windVol) - (0.005 * #windoors)
             playWind(windoor, true, windoorVol, 0.8)
@@ -116,6 +115,7 @@ local function windCheck(e)
         windPlaying = false
         return
     end
+    debugLog("Wind type: " .. windType)
 
     local useLast = (cellLast and common.checkCellDiff(cell, cellLast) == true and windType == windTypeLast) or false
 
@@ -160,7 +160,7 @@ local function windCheck(e)
                                 playWind(windoor, true, windoorVol, 0.8)
                             end
                         end
-                        interiorTimer:resume()
+                        interiorTimer:reset()
                     end
                 end
             end

--- a/common.lua
+++ b/common.lua
@@ -130,6 +130,21 @@ function this.getIndex(tab, elem)
 	return index
 end
 
+-- Emulates a set of unique elements. This function adds a new element to the set. --
+function this.setInsert(tab, elem)
+	if not this.getIndex(tab, elem) then
+		table.insert(tab, elem)
+	end
+end
+
+-- Emulates a set of unique elements. This function removes an existing element from the set. --
+function this.setRemove(tab, elem)
+	local index = this.getIndex(tab, elem)
+	if index then
+		table.remove(tab, index)
+	end
+end
+
 function this.findMatch(stringArray, str)
 	for _, pattern in pairs(stringArray) do
 		if string.find(str, pattern) then
@@ -137,6 +152,10 @@ function this.findMatch(stringArray, str)
 		end
 	end
 	return false
+end
+
+function this.isTimerAlive(t)
+    return t and t.state and (t.state < 2) or false
 end
 
 function this.cellIsInterior(cell)

--- a/moduleData.lua
+++ b/moduleData.lua
@@ -2,7 +2,6 @@ return {
     ["outdoor"] = {
         old = nil,
         new = nil,
-        blockedTracks = {},
         faderData = {
             ["out"] = {
                 duration = 3.5,
@@ -17,7 +16,6 @@ return {
     ["populated"] = {
         old = nil,
         new = nil,
-        blockedTracks = {},
         faderData = {
             ["out"] = {
                 duration = 4.0,
@@ -32,7 +30,6 @@ return {
     ["interior"] = {
         old = nil,
         new = nil,
-        blockedTracks = {},
         faderData = {
             ["out"] = {
                 duration = 3.0,
@@ -47,7 +44,6 @@ return {
 	["interiorWeather"] = {
         old = nil,
         new = nil,
-        blockedTracks = {},
         faderData = {
             ["out"] = {
                 duration = 5.0,
@@ -62,7 +58,6 @@ return {
     ["wind"] = {
         old = nil,
         new = nil,
-        blockedTracks = {},
         faderData = {
             ["out"] = {
                 duration = 5.0,
@@ -77,7 +72,6 @@ return {
     ["rainOnStatics"] = {
         old = nil,
         new = nil,
-        blockedTracks = {},
         faderData = {
             ["out"] = {
                 duration = 0.7,

--- a/moduleData.lua
+++ b/moduleData.lua
@@ -1,0 +1,92 @@
+return {
+    ["outdoor"] = {
+        old = nil,
+        new = nil,
+        blockedTracks = {},
+        faderData = {
+            ["out"] = {
+                duration = 3.5,
+                inProgress = {},
+            },
+            ["in"] = {
+                duration = 4.5,
+                inProgress = {},
+            },
+        },
+    },
+    ["populated"] = {
+        old = nil,
+        new = nil,
+        blockedTracks = {},
+        faderData = {
+            ["out"] = {
+                duration = 4.0,
+                inProgress = {},
+            },
+            ["in"] = {
+                duration = 4.0,
+                inProgress = {},
+            },
+        },
+    },
+    ["interior"] = {
+        old = nil,
+        new = nil,
+        blockedTracks = {},
+        faderData = {
+            ["out"] = {
+                duration = 3.0,
+                inProgress = {},
+            },
+            ["in"] = {
+                duration = 3.0,
+                inProgress = {},
+            },
+        },
+	},
+	["interiorWeather"] = {
+        old = nil,
+        new = nil,
+        blockedTracks = {},
+        faderData = {
+            ["out"] = {
+                duration = 5.0,
+                inProgress = {},
+            },
+            ["in"] = {
+                duration = 5.0,
+                inProgress = {},
+            },
+        },
+	},
+    ["wind"] = {
+        old = nil,
+        new = nil,
+        blockedTracks = {},
+        faderData = {
+            ["out"] = {
+                duration = 5.0,
+                inProgress = {},
+            },
+            ["in"] = {
+                duration = 5.0,
+                inProgress = {},
+            },
+        },
+    },
+    ["rainOnStatics"] = {
+        old = nil,
+        new = nil,
+        blockedTracks = {},
+        faderData = {
+            ["out"] = {
+                duration = 0.7,
+                inProgress = {},
+            },
+            ["in"] = {
+                duration = 0.7,
+                inProgress = {},
+            },
+        },
+    },
+}

--- a/soundBuilder.lua
+++ b/soundBuilder.lua
@@ -2,7 +2,7 @@ local this = {}
 
 -- Imports
 local common = require("tew.AURA.common")
-local sounds = require("tew.AURA.sounds")
+local soundData = require("tew.AURA.soundData")
 
 -- Load logger
 local debugLog = common.debugLog
@@ -64,16 +64,16 @@ local function buildClearSounds()
 	debugLog("|---------------------- Building clear weather table. ----------------------|\n")
 	for climate in lfs.dir(AURAdir .. climDir) do
 		if climate ~= ".." and climate ~= "." then
-			sounds.clear[climate] = {}
+			soundData.clear[climate] = {}
 			for time in lfs.dir(AURAdir .. climDir .. climate) do
 				if time ~= ".." and time ~= "." then
-					sounds.clear[climate][time] = {}
+					soundData.clear[climate][time] = {}
 					for soundfile in lfs.dir(AURAdir .. climDir .. climate .. "\\" .. time) do
 						if soundfile ~= ".." and soundfile ~= "." then
 							if string.endswith(soundfile, ".wav") then
 								local objectId = string.sub(climate .. "_" .. time .. "_" .. soundfile, 1, -5)
 								local filename = soundDir .. climDir .. climate .. "\\" .. time .. "\\" .. soundfile
-								createSound(objectId, filename, sounds.clear[climate][time])
+								createSound(objectId, filename, soundData.clear[climate][time])
 							end
 						end
 					end
@@ -98,12 +98,12 @@ end
 -- Populated --
 local function buildPopulatedSounds()
 	debugLog("|---------------------- Building populated sounds table. ----------------------|\n")
-	for populatedType, _ in pairs(sounds.populated) do
+	for populatedType, _ in pairs(soundData.populated) do
 		for soundfile in lfs.dir(AURAdir .. popDir .. populatedType) do
 			if soundfile and soundfile ~= ".." and soundfile ~= "." and string.endswith(soundfile, ".wav") then
 				local objectId = string.sub("P_" .. populatedType .. "_" .. soundfile, 1, -5)
 				local filename = soundDir .. popDir .. populatedType .. "\\" .. soundfile
-				createSound(objectId, filename, sounds.populated[populatedType])
+				createSound(objectId, filename, soundData.populated[populatedType])
 			end
 		end
 	end
@@ -112,12 +112,12 @@ end
 -- Interior --
 local function buildInteriorSounds()
 	debugLog("|---------------------- Building interior sounds table. ----------------------|\n")
-	for interiorType, _ in pairs(sounds.interior) do
+	for interiorType, _ in pairs(soundData.interior) do
 		for soundfile in lfs.dir(AURAdir .. interiorDir .. interiorType) do
 			if soundfile and soundfile ~= ".." and soundfile ~= "." and string.endswith(soundfile, ".wav") then
 				local objectId = string.sub("I_" .. interiorType .. "_" .. soundfile, 1, -5)
 				local filename = soundDir .. interiorDir .. interiorType .. "\\" .. soundfile
-				createSound(objectId, filename, sounds.interior[interiorType])
+				createSound(objectId, filename, soundData.interior[interiorType])
 			end
 		end
 	end
@@ -130,7 +130,7 @@ local function buildTavernSounds()
 			if soundfile and soundfile ~= ".." and soundfile ~= "." and string.endswith(soundfile, ".wav") then
 				local objectId = string.sub("I_tav_" .. folder .. "_" .. soundfile, 1, -5)
 				local filename = soundDir .. interiorDir .. "tav\\" .. folder .. "\\" .. soundfile
-				createSound(objectId, filename, sounds.interior["tav"][folder])
+				createSound(objectId, filename, soundData.interior["tav"][folder])
 			end
 		end
 	end
@@ -147,8 +147,8 @@ local function buildWeatherSounds()
 
 	filename = soundDir .. wDir .. "\\big\\rm.wav"
 	objectId = "tew_b_rainmedium"
-	createSound(objectId, filename, sounds.interiorWeather["big"], 4)
-	createSound(objectId, filename, sounds.interiorWeather["big"], 5)
+	createSound(objectId, filename, soundData.interiorWeather["big"], 4)
+	createSound(objectId, filename, soundData.interiorWeather["big"], 5)
 
 	filename = soundDir .. wDir .. "\\big\\rh.wav"
 	objectId = "tew_b_rainheavy"
@@ -160,8 +160,8 @@ local function buildWeatherSounds()
 
 	filename = soundDir .. wDir .. "\\sma\\rm.wav"
 	objectId = "tew_s_rainmedium"
-	createSound(objectId, filename, sounds.interiorWeather["sma"], 4)
-	createSound(objectId, filename, sounds.interiorWeather["sma"], 5)
+	createSound(objectId, filename, soundData.interiorWeather["sma"], 4)
+	createSound(objectId, filename, soundData.interiorWeather["sma"], 5)
 
 	filename = soundDir .. wDir .. "\\sma\\rh.wav"
 	objectId = "tew_s_rainheavy"
@@ -173,8 +173,8 @@ local function buildWeatherSounds()
 
 	filename = soundDir .. wDir .. "\\ten\\rm.wav"
 	objectId = "tew_t_rainmedium"
-	createSound(objectId, filename, sounds.interiorWeather["ten"], 4)
-	createSound(objectId, filename, sounds.interiorWeather["ten"], 5)
+	createSound(objectId, filename, soundData.interiorWeather["ten"], 4)
+	createSound(objectId, filename, soundData.interiorWeather["ten"], 5)
 
 	filename = soundDir .. wDir .. "\\ten\\rh.wav"
 	objectId = "tew_t_rainheavy"
@@ -315,10 +315,10 @@ local function getWeatherSounds()
 	local blightSound = tes3.getSound("Blight")
 	local blizzardSound = tes3.getSound("BM Blizzard")
 
-	for type in pairs(sounds.interiorWeather) do
-		table.insert(sounds.interiorWeather[type], 6, ashSound)
-		table.insert(sounds.interiorWeather[type], 7, blightSound)
-		table.insert(sounds.interiorWeather[type], 9, blizzardSound)
+	for type in pairs(soundData.interiorWeather) do
+		table.insert(soundData.interiorWeather[type], 6, ashSound)
+		table.insert(soundData.interiorWeather[type], 7, blightSound)
+		table.insert(soundData.interiorWeather[type], 9, blizzardSound)
 	end
 end
 
@@ -345,9 +345,9 @@ function this.build()
 	manifest = json.loadfile(manifestPath) or {}
 
 	buildClearSounds()
-	buildContextSounds(quietDir, sounds.quiet)
-	buildContextSounds(warmDir, sounds.warm)
-	buildContextSounds(coldDir, sounds.cold)
+	buildContextSounds(quietDir, soundData.quiet)
+	buildContextSounds(warmDir, soundData.warm)
+	buildContextSounds(coldDir, soundData.cold)
 	buildPopulatedSounds()
 	buildInteriorSounds()
 	buildTavernSounds()

--- a/soundData.lua
+++ b/soundData.lua
@@ -1,0 +1,65 @@
+local this = {}
+
+this.clear = {}
+this.quiet = {}
+this.warm = {}
+this.cold = {}
+
+this.populated = {
+	["ash"] = {},
+	["dae"] = {},
+	["dar"] = {},
+	["dwe"] = {},
+	["imp"] = {},
+	["nor"] = {},
+	["n"] = {}
+}
+
+this.interior = {
+	["aba"] = {},
+	["alc"] = {},
+	["cou"] = {},
+	["cav"] = {},
+	["clo"] = {},
+	["dae"] = {},
+	["dwe"] = {},
+	["ice"] = {},
+	["mag"] = {},
+	["fig"] = {},
+	["tem"] = {},
+	["lib"] = {},
+	["smi"] = {},
+	["tra"] = {},
+	["tom"] = {},
+	["tav"] = {
+		["imp"] = {},
+		["dar"] = {},
+		["nor"] = {},
+	}
+}
+
+this.interiorWeather = {
+	["big"] = {
+		[4] = nil,
+		[5] = nil,
+		[6] = nil,
+		[7] = nil,
+		[9] = nil
+	},
+	["sma"] = {
+		[4] = nil,
+		[5] = nil,
+		[6] = nil,
+		[7] = nil,
+		[9] = nil
+	},
+	["ten"] = {
+		[4] = nil,
+		[5] = nil,
+		[6] = nil,
+		[7] = nil,
+		[9] = nil
+	}
+}
+
+return this

--- a/sounds.lua
+++ b/sounds.lua
@@ -3,309 +3,16 @@ local this = {}
 
 -- Imports
 local common = require("tew.AURA.common")
+local soundData = require("tew.AURA.soundData")
+local moduleData = require("tew.AURA.moduleData")
+local fader = require("tew.AURA.fader")
 
 -- Logger
 local debugLog = common.debugLog
 
 -- Constants
-local STEP = 0.012
-local TICK = 0.1
 local MAX = 1
 local MIN = 0
-
--- Array attributes
-this.clear = {}
-this.quiet = {}
-this.warm = {}
-this.cold = {}
-
--- Blocker
-local blocked = {}
-
-this.populated = {
-	["ash"] = {},
-	["dae"] = {},
-	["dar"] = {},
-	["dwe"] = {},
-	["imp"] = {},
-	["nor"] = {},
-	["n"] = {}
-}
-
-this.interior = {
-	["aba"] = {},
-	["alc"] = {},
-	["cou"] = {},
-	["cav"] = {},
-	["clo"] = {},
-	["dae"] = {},
-	["dwe"] = {},
-	["ice"] = {},
-	["mag"] = {},
-	["fig"] = {},
-	["tem"] = {},
-	["lib"] = {},
-	["smi"] = {},
-	["tra"] = {},
-	["tom"] = {},
-	["tav"] = {
-		["imp"] = {},
-		["dar"] = {},
-		["nor"] = {},
-	}
-}
-
-this.interiorWeather = {
-	["big"] = {
-		[4] = nil,
-		[5] = nil,
-		[6] = nil,
-		[7] = nil,
-		[9] = nil
-	},
-	["sma"] = {
-		[4] = nil,
-		[5] = nil,
-		[6] = nil,
-		[7] = nil,
-		[9] = nil
-	},
-	["ten"] = {
-		[4] = nil,
-		[5] = nil,
-		[6] = nil,
-		[7] = nil,
-		[9] = nil
-	}
-}
-
-
-local modules = {
-	["outdoor"] = {
-		old = nil,
-		new = nil
-	},
-	["populated"] = {
-		old = nil,
-		new = nil
-	},
-	["interior"] = {
-		old = nil,
-		new = nil
-	},
-	["interiorWeather"] = {
-		old = nil,
-		new = nil
-	},
-	["wind"] = {
-		old = nil,
-		new = nil
-	}
-}
-
--- Remove sound if it's already been faded in/out --
-local function removeBlocked(track)
-	for k, v in pairs(blocked) do
-		if v == track then
-			table.remove(blocked, k)
-		end
-	end
-end
-
--- Check if the sound is not being faded in/out, block if yes --
-local function isBlocked(track)
-	for _, v in pairs(blocked) do
-		if v == track then debugLog("Track blocked: " .. track.id) return true end
-	end
-end
-
--- Controls fading in --
-local function fadeIn(ref, volume, track, module)
-
-	-- We can sometimes get calls where no sound is actually playing, get out if it is so --
-	if not track or not tes3.getSoundPlaying { sound = track, reference = ref } then debugLog("No track to fade in. Returning.") return end
-
-	-- If the track is already fading in, block it and check later --
-	if isBlocked(track) then
-		timer.start {
-			callback = function()
-				fadeIn(ref, volume, track, module)
-			end,
-			type = timer.real,
-			iterations = 1,
-			duration = 2
-		}
-		return
-	end
-
-	debugLog("Running fade in for: " .. track.id)
-	table.insert(blocked, track)
-
-	-- Magic maths --
-	local TIME = TICK * volume / STEP
-	local ITERS = math.ceil(volume / STEP)
-	local runs = 1
-
-	-- Inline function to ensure we can register different iterations of this on different sounds --
-	local function fader()
-		local incremented = STEP * runs
-
-		if not tes3.getSoundPlaying { sound = track, reference = ref } then
-			debugLog("In not playing: " .. track.id)
-			return
-		end
-
-		tes3.adjustSoundVolume { sound = track, volume = incremented, reference = ref }
-		debugLog("Adjusting volume in: " .. track.id .. " | " .. tostring(incremented))
-		runs = runs + 1
-		debugLog("In runs for track: " .. track.id .. " : " .. runs)
-	end
-
-	-- Remove from blocked once we're done --
-	local function queuer()
-		modules[module].old = track
-		removeBlocked(track)
-		debugLog("Fade in for " .. track.id .. " finished in: " .. tostring(TIME) .. " s.")
-	end
-
-	debugLog("Iterations: " .. tostring(ITERS))
-	debugLog("Time: " .. tostring(TIME))
-
-	-- Start fading --
-	timer.start {
-		iterations = ITERS,
-		duration = TICK,
-		callback = fader
-	}
-
-	-- Clean up afterwards --
-	timer.start {
-		iterations = 1,
-		duration = TIME + 0.1, -- Ridiculous but required --
-		callback = queuer
-	}
-end
-
--- Same as above, just backwards --
-local function fadeOut(ref, volume, track, module)
-
-	if not track or not tes3.getSoundPlaying { sound = track, reference = ref } then debugLog("No track to fade out. Returning.") return end
-
-	if isBlocked(track) then
-		timer.start {
-			callback = function()
-				fadeOut(ref, volume, track, module)
-			end,
-			type = timer.real,
-			iterations = 1,
-			duration = 2
-		}
-		return
-	end
-
-	debugLog("Running fade out for: " .. track.id)
-	table.insert(blocked, track)
-
-	local TIME = TICK * volume / STEP
-	local ITERS = math.ceil(volume / STEP)
-	local runs = ITERS
-
-	local function fader()
-		local incremented = STEP * runs
-		if not tes3.getSoundPlaying { sound = track, reference = ref } then
-			debugLog("Out not playing: " .. track.id)
-			return
-		end
-
-		tes3.adjustSoundVolume { sound = track, volume = incremented, reference = ref }
-		debugLog("Adjusting volume out: " .. track.id .. " | " .. tostring(incremented))
-		runs = runs - 1
-		debugLog("Out runs for track: " .. track.id .. " : " .. runs)
-	end
-
-	local function queuer()
-		modules[module].old = track
-		removeBlocked(track)
-		if tes3.getSoundPlaying { sound = track, reference = ref } then tes3.removeSound { sound = track, reference = ref } end
-		debugLog("Fade out for " .. track.id .. " finished in: " .. tostring(TIME) .. " s.")
-	end
-
-	debugLog("Iterations: " .. tostring(ITERS))
-	debugLog("Time: " .. tostring(TIME))
-
-	timer.start {
-		iterations = ITERS,
-		duration = TICK,
-		callback = fader
-	}
-
-	timer.start {
-		iterations = 1,
-		duration = TIME + 0.1,
-		callback = queuer
-	}
-end
-
--- Simple crossfade using available faders --
-local function crossFade(ref, volume, trackOld, trackNew, module)
-	if not trackOld or not trackNew then return end
-	debugLog("Running crossfade for: " .. trackOld.id .. ", " .. trackNew.id)
-	fadeOut(ref, volume, trackOld, module)
-	fadeIn(ref, volume, trackNew, module)
-end
-
--- Sometimes we need to just remove the sounds without fading --
-function this.removeImmediate(options)
-	debugLog("Immediately removing sounds for module: " .. options.module)
-
-	local ref = options.reference or tes3.mobilePlayer.reference
-
-	-- Remove old file if playing (for instance if fade out didn't quite finish yet) --
-	if modules[options.module].old then
-		removeBlocked(modules[options.module].old)
-		if tes3.getSoundPlaying { sound = modules[options.module].old, reference = ref } then
-			tes3.removeSound { sound = modules[options.module].old, reference = ref }
-			debugLog(modules[options.module].old.id .. " removed.")
-		else
-			debugLog("Old track not playing.")
-		end
-	end
-
-	-- Remove the new file as well --
-	if modules[options.module].new then
-		removeBlocked(modules[options.module].old)
-		if tes3.getSoundPlaying { sound = modules[options.module].new, reference = ref } then
-			tes3.removeSound { sound = modules[options.module].new, reference = ref }
-			modules[options.module].old = modules[options.module].new
-			debugLog(modules[options.module].new.id .. " removed.")
-		else
-			debugLog("New track not playing.")
-		end
-	end
-end
-
--- Remove the sound for a given module, but with fade out --
-function this.remove(options)
-	debugLog("Removing sounds for module: " .. options.module)
-	local ref = options.reference or tes3.mobilePlayer.reference
-	local volume = options.volume or MAX
-
-	if modules[options.module].old
-		and tes3.getSoundPlaying { sound = modules[options.module].old, reference = ref }
-	then
-		fadeOut(ref, volume, modules[options.module].old, options.module)
-	else
-		debugLog("Old track not playing.")
-	end
-
-	if modules[options.module].new
-		and tes3.getSoundPlaying { sound = modules[options.module].new, reference = ref }
-	then
-		fadeOut(ref, volume, modules[options.module].new, options.module)
-	else
-		debugLog("New track not playing.")
-	end
-end
 
 -- Resolve options and return the randomised track per conditions given --
 local function getTrack(options)
@@ -318,38 +25,40 @@ local function getTrack(options)
 	if options.module == "outdoor" then
 		debugLog("Got outdoor module.")
 		if not (options.climate) or not (options.time) then
+			-- Not implemented. This module only uses the clear weather table.
+			-- This part of the if statement has no purpose as of now.
 			if options.type == "quiet" then
 				debugLog("Got quiet type.")
-				table = this.quiet
+				table = soundData.quiet
 			end
 		else
 			local climate = options.climate
 			local time = options.time
 			debugLog("Got " .. climate .. " climate and " .. time .. " time.")
-			table = this.clear[climate][time]
+			table = soundData.clear[climate][time]
 		end
 	elseif options.module == "populated" then
 		debugLog("Got populated module.")
 		if options.type == "night" then
 			debugLog("Got populated night.")
-			table = this.populated["n"]
+			table = soundData.populated["n"]
 		elseif options.type == "day" then
 			debugLog("Got populated day.")
-			table = this.populated[options.typeCell]
+			table = soundData.populated[options.typeCell]
 		end
 	elseif options.module == "interior" then
 		debugLog("Got interior module.")
 		if options.race then
 			debugLog("Got tavern for " .. options.race .. " race.")
-			table = this.interior["tav"][options.race]
+			table = soundData.interior["tav"][options.race]
 		else
 			debugLog("Got interior " .. options.type .. " type.")
-			table = this.interior[options.type]
+			table = soundData.interior[options.type]
 		end
 	elseif options.module == "interiorWeather" then
 		debugLog("Got interior weather module. Weather: " .. options.weather)
 		debugLog("Got interior type: " .. options.type)
-		local intWTrack = this.interiorWeather[options.type][options.weather]
+		local intWTrack = soundData.interiorWeather[options.type][options.weather]
 		if intWTrack then
 			debugLog("Got track: " .. intWTrack.id)
 			return intWTrack
@@ -360,13 +69,13 @@ local function getTrack(options)
 	elseif options.module == "wind" then
 		if options.type == "quiet" then
 			debugLog("Got wind quiet type.")
-			table = this.quiet
+			table = soundData.quiet
 		elseif options.type == "warm" then
 			debugLog("Got warm type.")
-			table = this.warm
+			table = soundData.warm
 		elseif options.type == "cold" then
 			debugLog("Got cold type.")
-			table = this.cold
+			table = soundData.cold
 		end
 	end
 
@@ -377,8 +86,8 @@ local function getTrack(options)
 	end
 
 	local newTrack = table[math.random(1, #table)]
-	if modules[options.module].old and #table > 1 then
-		while newTrack.id == modules[options.module].old.id do
+	if moduleData[options.module].old and #table > 1 then
+		while newTrack.id == moduleData[options.module].old.id do
 			newTrack = table[math.random(1, #table)]
 		end
 	end
@@ -388,38 +97,117 @@ local function getTrack(options)
 	return newTrack
 end
 
+function this.getTrackPlaying(track, ref)
+	local ref = ref or tes3.mobilePlayer.reference
+	if track and tes3.getSoundPlaying{sound = track, reference = ref} then
+		return track
+	end
+end
+
+-- Sometimes we need to just remove the sounds without fading --
+-- If fade is in progress for the given track and ref, we'll cancel the fade first --
+function this.removeImmediate(options)
+	debugLog("Immediately removing sounds for module: " .. options.module)
+
+	local ref = options.reference or tes3.mobilePlayer.reference
+
+	-- Remove old file if playing --
+	local oldTrack = this.getTrackPlaying(moduleData[options.module].old, ref)
+	if oldTrack then
+		debugLog("Removing .old")
+		fader.cancel(options.module, oldTrack, ref)
+		tes3.removeSound{sound = oldTrack, reference = ref}
+		debugLog(tostring(ref) .. " -> " .. oldTrack.id .. " removed.")
+	end
+
+	-- Remove the new file as well --
+	local newTrack = this.getTrackPlaying(moduleData[options.module].new, ref)
+	if newTrack then
+		debugLog("Removing .new")
+		fader.cancel(options.module, newTrack, ref)
+		tes3.removeSound{sound = newTrack, reference = ref}
+		debugLog(tostring(ref) .. " -> " .. newTrack.id .. " removed.")
+	end
+end
+
+-- Remove the sound for a given module, but with fade out --
+function this.remove(options)
+	debugLog("Removing sounds for module: " .. options.module)
+
+	local oldTrack = this.getTrackPlaying(moduleData[options.module].old, options.reference)
+	local newTrack = this.getTrackPlaying(moduleData[options.module].new, options.reference)
+	local oldTrackOpts, newTrackOpts
+
+	if oldTrack then
+		debugLog("Fade out .old")
+		oldTrackOpts = table.copy(options)
+		oldTrackOpts.track = oldTrack
+		fader.fadeOut(oldTrackOpts)
+	end
+
+	if newTrack then
+		debugLog("Fade out .new")
+		newTrackOpts = table.copy(options)
+		newTrackOpts.track = newTrack
+		fader.fadeOut(newTrackOpts)
+	end
+
+	moduleData[options.module].old = moduleData[options.module].new
+end
+
+local function playLast(options)
+	local moduleName = options.module
+	local track = moduleData[moduleName].new
+	local volume = options.volume or MAX
+	local pitch = options.pitch or MAX
+	local ref = options.reference or tes3.mobilePlayer.reference
+
+	debugLog("Immediately restarting: " .. track.id)
+
+	fader.cancel(moduleName, track, ref)
+
+	if tes3.getSoundPlaying{sound = track, reference = ref} then
+		tes3.removeSound{sound = track, reference = ref}
+	end
+
+	debugLog(string.format("[%s] Playing with volume %s: %s -> %s", moduleName, volume, track.id, tostring(ref)))
+	tes3.playSound{
+		sound = track,
+		reference = ref,
+		volume = volume,
+		pitch = pitch,
+		loop = true,
+	}
+
+	moduleData[moduleName].old = moduleData[moduleName].new
+end
+
 -- Sometiems we need to play a sound immediately as well --
 function this.playImmediate(options)
-	local ref = options.reference or tes3.mobilePlayer.reference
-	local volume = options.volume or MAX
-
 	-- Get the last track so that we're not randomising each time we change int/ext cells within same conditions --
-	if options.last and modules[options.module].new then
-		if tes3.getSoundPlaying { sound = modules[options.module].new, reference = ref } then tes3.removeSound { sound = modules[options.module].new, reference = ref } end
-		debugLog("Immediately restaring: " .. modules[options.module].new.id)
-		tes3.playSound {
-			sound = modules[options.module].new,
-			loop = true,
-			reference = ref,
-			volume = volume,
-			pitch = options.pitch or MAX
-		}
-		modules[options.module].old = modules[options.module].new
+	if options.last and moduleData[options.module].new then
+		playLast(options)
 	else
+		local moduleName = options.module
+		local ref = options.reference or tes3.mobilePlayer.reference
+		local volume = options.volume or MAX
+		local pitch = options.pitch or MAX
 		local newTrack = getTrack(options)
-		modules[options.module].old = modules[options.module].new
-		modules[options.module].new = newTrack
-
 		if newTrack then
-			debugLog("Immediately playing new track: " .. newTrack.id .. " for module: " .. options.module)
-
-			tes3.playSound {
+			debugLog("Immediately playing new track: " .. newTrack.id .. " for module: " .. moduleName)
+			fader.cancel(moduleName, newTrack, ref)
+			debugLog(string.format("[%s] Playing with volume %s: %s -> %s", moduleName, volume, newTrack.id, tostring(ref)))
+			tes3.playSound{
 				sound = newTrack,
-				loop = true,
 				reference = ref,
 				volume = volume,
-				pitch = options.pitch or MAX
+				pitch = pitch,
+				loop = true,
 			}
+			moduleData[moduleName].old = moduleData[moduleName].new
+			moduleData[moduleName].new = newTrack
+		else
+			debugLog("No track selected. Returning.")
 		end
 	end
 end
@@ -427,50 +215,32 @@ end
 -- Supporting kwargs here
 -- Main entry point, resolves all data received and decides what to do next --
 function this.play(options)
-	-- If no ref (windoor etc.) given, use player --
-	local ref = options.reference or tes3.mobilePlayer.reference
-
-	-- Need this for fader calcs --
-	local volume = options.volume or MAX
-
-	if options.last and modules[options.module].new then
-		if tes3.getSoundPlaying { sound = modules[options.module].new, reference = ref } then tes3.removeSound { sound = modules[options.module].new, reference = ref } end
-		debugLog("Immediately restaring: " .. modules[options.module].new.id)
-		tes3.playSound {
-			sound = modules[options.module].new,
-			loop = true,
-			reference = ref,
-			volume = volume,
-			pitch = options.pitch or MAX
-		}
-		modules[options.module].old = modules[options.module].new
+	if options.last and moduleData[options.module].new then
+		playLast(options)
 	else
+		local oldTrack, newTrack, fadeOutOpts, fadeInOpts
 		-- Get the new track, if nothing is returned then bugger off (shouldn't really happen at all, but oh well) --
-		local newTrack = getTrack(options)
+		newTrack = getTrack(options)
 		if not newTrack then debugLog("No track selected. Returning.") return end
 
+		-- If old track is playing, then we'll first fade it out. Otherwise, we'll just fade in the new track. --
+		oldTrack = this.getTrackPlaying(moduleData[options.module].old, options.reference)
+
 		-- Move the queue forward --
-		modules[options.module].old = modules[options.module].new
-		modules[options.module].new = newTrack
+		moduleData[options.module].old = moduleData[options.module].new
+		moduleData[options.module].new = newTrack
 
-		debugLog("Playing new track: " .. newTrack.id .. " for module: " .. options.module)
-
-		-- Play the sound with 0 volume, decide the fader method later --
-		tes3.playSound {
-			sound = newTrack,
-			loop = true,
-			reference = ref,
-			volume = MIN,
-			pitch = options.pitch or MAX
-		}
-
-		-- Crossfade if old track is playing and is different from new sound, otherwise fade in --
-		if modules[options.module].old and
-			tes3.getSoundPlaying { sound = modules[options.module].old, reference = ref } and
-			(modules[options.module].old ~= newTrack) then
-			crossFade(ref, volume, modules[options.module].old, newTrack, options.module)
-		else
-			fadeIn(ref, volume, newTrack, options.module)
+		if oldTrack then
+			debugLog("Fade out oldTrack.")
+			fadeOutOpts = table.copy(options)
+			fadeOutOpts.track = oldTrack
+			fader.fadeOut(fadeOutOpts)
+		end
+		if newTrack then
+			debugLog("Fade in newTrack.")
+			fadeInOpts = table.copy(options)
+			fadeInOpts.track = newTrack
+			fader.fadeIn(fadeInOpts)
 		end
 	end
 end


### PR DESCRIPTION
Not just a makeover, this is Holy l'oreal de Paris. And there I was thinking this was only going to be a walk in the park 🤣 

- Moved weather attributes tables along with `populated`, `interior` and `interiorWeather` types into a new file: `soundData.lua`. The soundBuilder now requires this file instead of the whole `sounds.lua` file to build sounds. `rainSounds.lua` will do the same.
- Module data such as `old` and `new` tracks, `blockedTracks`, and `faderData` are now being stored in a separate file: `moduleData.lua`. The purpose of this being each module can now have access to this data without importing the whole `sounds.lua` file. Useful for modules which don't make use of the functions in sounds.lua (see rainOnStatics).
- Simplified fader. Got rid of the crossfade function. Since `fadeOut` and `fadeIn` run independently of each other, `sounds.play()` should automatically know whether to first fade out `oldTrack` before fading in `newTrack`, which is, essentially crossfade.
- Fade in and fade out can also be called directly from within any module, by only importing the `fader.lua` file. This adds some flexibility for modules that don't require `sounds.lua` functionality.
- Duration-based fader means no need of a `STEP` constant. Per-module default fade duration configs are stored in the `faderData` table, which sits in `moduleData.lua`.
- Custom duration can be passed as an option to the fader, which takes precedence over default values.
- Fades for a given module, track and reference can now be instantly canceled by calling `fader.cancel()`.

Let me know if you like this approach or if you have other suggestions.