### PR TITLE
rainSounds/rainOnStatics patches

### DIFF
--- a/Misc/rainOnStatics.lua
+++ b/Misc/rainOnStatics.lua
@@ -199,7 +199,7 @@ local function addToCache(ref)
 		return
 	end
 	-- We only add a static to the cache if it's not already in there.
-	if not common.getIndex(staticsCache, ref) then
+	if not table.find(staticsCache, ref) then
 		if not ref.tempData.tew then
 			ref.tempData.tew = {}
 		end
@@ -223,7 +223,7 @@ local function removeFromCache(ref)
 	if (#staticsCache == 0) then return end
 
 	-- We need the ref's index for table.remove()
-	local index = common.getIndex(staticsCache, ref)
+	local index = table.find(staticsCache, ref)
 	if not index then return end
 
 	removeSound(ref)

--- a/Misc/rainOnStatics.lua
+++ b/Misc/rainOnStatics.lua
@@ -162,7 +162,8 @@ local function removeSound(ref)
 end
 
 local function isRainLoopSoundPlaying()
-    if WtC.currentWeather.rainLoopSound
+    if WtC.currentWeather
+	and WtC.currentWeather.rainLoopSound
 	and WtC.currentWeather.rainLoopSound:isPlaying() then
         return true
     else

--- a/Misc/rainSounds.lua
+++ b/Misc/rainSounds.lua
@@ -65,7 +65,7 @@ local function changeRainSounds()
     debugLog("Storm type: " .. stormyType)
 
     -- Remove vanilla sound if present, the next step will add the new sound --
-    if WtC.currentWeather.rainLoopSound then
+    if WtC.currentWeather and WtC.currentWeather.rainLoopSound then
         WtC.currentWeather.rainLoopSound:stop()
     end
 

--- a/common.lua
+++ b/common.lua
@@ -120,27 +120,16 @@ function this.getWindoors(cell)
 	end
 end
 
--- Pass me a table and an element and I'll tell you the index it's stored at --
-function this.getIndex(tab, elem)
-	local index = nil
-	for i, v in ipairs(tab) do
-		if (v == elem) then
-			index = i
-		end
-	end
-	return index
-end
-
 -- Emulates a set of unique elements. This function adds a new element to the set. --
 function this.setInsert(tab, elem)
-	if not this.getIndex(tab, elem) then
+	if not table.find(tab, elem) then
 		table.insert(tab, elem)
 	end
 end
 
 -- Emulates a set of unique elements. This function removes an existing element from the set. --
 function this.setRemove(tab, elem)
-	local index = this.getIndex(tab, elem)
+	local index = table.find(tab, elem)
 	if index then
 		table.remove(tab, index)
 	end


### PR DESCRIPTION
- Add `currentWeather` nil check to fix potential crash when starting a new game after loading an existing save. It appears that `currentWeather` is `nil` only until you step outside (e.g. you exit the chargen ship). This behavior only applies to this particular scenario.
- `table.find()` does exactly what `common.getIndex()` does, use builtin instead.